### PR TITLE
Add tests for websocket routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,27 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "flodgatt"
+version = "0.2.0"
+dependencies = [
+ "dotenv 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "postgres 0.16.0-rc.2 (git+https://github.com/sfackler/rust-postgres.git)",
+ "postgres-openssl 0.2.0-rc.1 (git+https://github.com/sfackler/rust-postgres.git)",
+ "pretty_env_logger 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "warp 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,27 +896,6 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ragequit"
-version = "0.1.0"
-dependencies = [
- "dotenv 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "postgres 0.16.0-rc.2 (git+https://github.com/sfackler/rust-postgres.git)",
- "postgres-openssl 0.2.0-rc.1 (git+https://github.com/sfackler/rust-postgres.git)",
- "pretty_env_logger 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "warp 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "ragequit"
+name = "flodgatt"
 description = "A blazingly fast drop-in replacement for the Mastodon streaming api server"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Daniel Long Sockwell <daniel@codesections.com", "Julian Laubstein <contact@julianlaubstein.de>"]
 edition = "2018"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,26 +1,24 @@
 //! Streaming server for Mastodon
 //!
 //!
-//! This server provides live, streaming updates for Mastodon clients.  Specifically, when a server
-//! is running this sever, Mastodon clients can use either Server Sent Events or WebSockets to
-//! connect to the server with the API described [in Mastodon's public API
+//! This server provides live, streaming updates for Mastodon clients.  Specifically, when a
+//! server is running this sever, Mastodon clients can use either Server Sent Events or
+//! WebSockets to connect to the server with the API described [in Mastodon's public API
 //! documentation](https://docs.joinmastodon.org/api/streaming/).
 //!
 //! # Data Flow
-//! * **Parsing the client request**
-//! When the client request first comes in, it is parsed based on the endpoint it targets (for
-//! server sent events), its query parameters, and its headers (for WebSocket).  Based on this
-//! data, we authenticate the user, retrieve relevant user data from Postgres, and determine the
-//! timeline targeted by the request.  Successfully parsing the client request results in generating
-//! a `User` and target `timeline` for the request.  If any requests are invalid/not authorized, we
-//! reject them in this stage.
-//! * **Streaming update from Redis to the client**:
-//! After the user request is parsed, we pass the `User` and `timeline` data on to the
-//! `ClientAgent`.  The `ClientAgent` is responsible for communicating the user's request to the
-//! `Receiver`, polling the `Receiver` for any updates, and then for wording those updates on to the
-//! client.  The `Receiver`, in tern, is responsible for managing the Redis subscriptions,
-//! periodically polling Redis, and sorting the replies from Redis into queues for when it is polled
-//! by the `ClientAgent`.
+//! * **Parsing the client request** When the client request first comes in, it is
+//! parsed based on the endpoint it targets (for server sent events), its query parameters,
+//! and its headers (for WebSocket).  Based on this data, we authenticate the user, retrieve
+//! relevant user data from Postgres, and determine the timeline targeted by the request.
+//! Successfully parsing the client request results in generating a `User` corresponding to
+//! the request.  If any requests are invalid/not authorized, we reject them in this stage.
+//! * **Streaming update from Redis to the client**: After the user request is parsed, we pass
+//! the `User` data on to the `ClientAgent`.  The `ClientAgent` is responsible for
+//! communicating the user's request to the `Receiver`, polling the `Receiver` for any
+//! updates, and then for wording those updates on to the client.  The `Receiver`, in tern, is
+//! responsible for managing the Redis subscriptions, periodically polling Redis, and sorting
+//! the replies from Redis into queues for when it is polled by the `ClientAgent`.
 //!
 //! # Concurrency
 //! The `Receiver` is created when the server is first initialized, and there is only one
@@ -31,11 +29,10 @@
 //! that the `Receiver`'s poll of Redis be fast, since there will only ever be one
 //! `Receiver`.
 //!
-//! # Configuration
-//! By default, the server uses config values from the `config.rs` module; these values can be
-//! overwritten with environmental variables or in the `.env` file.  The most important settings
-//! for performance control the frequency with which the `ClientAgent` polls the `Receiver` and
-//! the frequency with which the `Receiver` polls Redis.
+//! # Configuration By default, the server uses config values from the `config.rs` module;
+//! these values can be overwritten with environmental variables or in the `.env` file.  The
+//! most important settings for performance control the frequency with which the `ClientAgent`
+//! polls the `Receiver` and the frequency with which the `Receiver` polls Redis.
 //!
 pub mod config;
 pub mod parse_client_request;

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,11 +33,9 @@ fn main() {
         .recover(config::handle_errors);
 
     // WebSocket
-    let websocket_routes = ws::parse_query()
-        .and_then(ws::generate_timeline_and_update_user)
-        .untuple_one()
+    let websocket_routes = ws::extract_user_or_reject()
         .and(warp::ws::ws2())
-        .and_then(move |timeline: String, user: user::User, ws: Ws2| {
+        .and_then(move |user: user::User, ws: Ws2| {
             let token = user.access_token.clone();
 
             // Create a new ClientAgent

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
-use log::{log_enabled, Level};
-use ragequit::{
+use flodgatt::{
     config,
     parse_client_request::{sse, user, ws},
     redis_to_client_stream,
     redis_to_client_stream::ClientAgent,
 };
+use log::{log_enabled, Level};
 use warp::{ws::Ws2, Filter as WarpFilter};
 
 fn main() {
@@ -37,7 +37,6 @@ fn main() {
         .and(warp::ws::ws2())
         .and_then(move |user: user::User, ws: Ws2| {
             let token = user.access_token.clone();
-
             // Create a new ClientAgent
             let mut client_agent = client_agent_ws.clone_with_shared_receiver();
             // Assign that agent to generate a stream of updates for the user/timeline pair

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,18 +17,14 @@ fn main() {
     };
 
     // Server Sent Events
-    //
-    // For SSE, the API requires users to use different endpoints, so we first filter based on
-    // the endpoint.  Using that endpoint determine the `timeline` the user is requesting,
-    // the scope for that `timeline`, and authenticate the `User` if they provided a token.
-    let sse_routes = sse::filter_incomming_request()
+    let sse_routes = sse::extract_user_or_reject()
         .and(warp::sse())
         .map(
-            move |timeline: String, user: user::User, sse_connection_to_client: warp::sse::Sse| {
+            move |user: user::User, sse_connection_to_client: warp::sse::Sse| {
                 // Create a new ClientAgent
                 let mut client_agent = client_agent_sse.clone_with_shared_receiver();
-                // Assign that agent to generate a stream of updates for the user/timeline pair
-                client_agent.init_for_user(&timeline, user);
+                // Assign ClientAgent to generate stream of updates for the user/timeline pair
+                client_agent.init_for_user(user);
                 // send the updates through the SSE connection
                 redis_to_client_stream::send_updates_to_sse(client_agent, sse_connection_to_client)
             },
@@ -37,52 +33,20 @@ fn main() {
         .recover(config::handle_errors);
 
     // WebSocket
-    //
-    // For WS, the API specifies a single endpoint, so we extract the User/timeline pair
-    // directy from the query
-    let websocket_routes = ws::extract_user_and_query()
-        .and_then(move |mut user: user::User, q: ws::Query, ws: Ws2| {
+    let websocket_routes = ws::parse_query()
+        .and_then(ws::generate_timeline_and_update_user)
+        .untuple_one()
+        .and(warp::ws::ws2())
+        .and_then(move |timeline: String, user: user::User, ws: Ws2| {
             let token = user.access_token.clone();
-            let read_scope = user.scopes.clone();
-
-            let timeline = match q.stream.as_ref() {
-                // Public endpoints:
-                tl @ "public" | tl @ "public:local" if q.media => format!("{}:media", tl),
-                tl @ "public:media" | tl @ "public:local:media" => tl.to_string(),
-                tl @ "public" | tl @ "public:local" => tl.to_string(),
-                // Hashtag endpoints:
-                tl @ "hashtag" | tl @ "hashtag:local" => format!("{}:{}", tl, q.hashtag),
-                // Private endpoints: User
-                "user" if user.logged_in && (read_scope.all || read_scope.statuses) => {
-                    format!("{}", user.id)
-                }
-                "user:notification" if user.logged_in && (read_scope.all || read_scope.notify) => {
-                    user = user.set_filter(user::Filter::Notification);
-                    format!("{}", user.id)
-                }
-                // List endpoint:
-                "list" if user.owns_list(q.list) && (read_scope.all || read_scope.lists) => {
-                    format!("list:{}", q.list)
-                }
-                // Direct endpoint:
-                "direct" if user.logged_in && (read_scope.all || read_scope.statuses) => {
-                    "direct".to_string()
-                }
-                // Reject unathorized access attempts for private endpoints
-                "user" | "user:notification" | "direct" | "list" => {
-                    return Err(warp::reject::custom("Error: Invalid Access Token"))
-                }
-                // Other endpoints don't exist:
-                _ => return Err(warp::reject::custom("Error: Nonexistent WebSocket query")),
-            };
 
             // Create a new ClientAgent
             let mut client_agent = client_agent_ws.clone_with_shared_receiver();
             // Assign that agent to generate a stream of updates for the user/timeline pair
-            client_agent.init_for_user(&timeline, user);
+            client_agent.init_for_user(user);
             // send the updates through the WS connection (along with the User's access_token
             // which is sent for security)
-            Ok((
+            Ok::<_, warp::Rejection>((
                 ws.on_upgrade(move |socket| {
                     redis_to_client_stream::send_updates_to_ws(socket, client_agent)
                 }),

--- a/src/parse_client_request/mod.rs
+++ b/src/parse_client_request/mod.rs
@@ -3,3 +3,27 @@ pub mod query;
 pub mod sse;
 pub mod user;
 pub mod ws;
+
+#[derive(Debug)]
+pub struct Query {
+    pub access_token: Option<String>,
+    pub stream: String,
+    pub media: bool,
+    pub hashtag: String,
+    pub list: i64,
+}
+
+impl Query {
+    pub fn update_access_token(
+        self,
+        token: Option<String>,
+    ) -> Result<Self, warp::reject::Rejection> {
+        match token {
+            Some(token) => Ok(Self {
+                access_token: Some(token),
+                ..self
+            }),
+            None => Ok(self),
+        }
+    }
+}

--- a/src/parse_client_request/mod.rs
+++ b/src/parse_client_request/mod.rs
@@ -1,29 +1,5 @@
-//! Parse the client request and return a 'timeline' and a (maybe authenticated) `User`
+//! Parse the client request and return a (possibly authenticated) `User`
 pub mod query;
 pub mod sse;
 pub mod user;
 pub mod ws;
-
-#[derive(Debug)]
-pub struct Query {
-    pub access_token: Option<String>,
-    pub stream: String,
-    pub media: bool,
-    pub hashtag: String,
-    pub list: i64,
-}
-
-impl Query {
-    pub fn update_access_token(
-        self,
-        token: Option<String>,
-    ) -> Result<Self, warp::reject::Rejection> {
-        match token {
-            Some(token) => Ok(Self {
-                access_token: Some(token),
-                ..self
-            }),
-            None => Ok(self),
-        }
-    }
-}

--- a/src/parse_client_request/query.rs
+++ b/src/parse_client_request/query.rs
@@ -3,7 +3,31 @@ use serde_derive::Deserialize;
 use warp::filters::BoxedFilter;
 use warp::Filter as WarpFilter;
 
-macro_rules! query {
+#[derive(Debug)]
+pub struct Query {
+    pub access_token: Option<String>,
+    pub stream: String,
+    pub media: bool,
+    pub hashtag: String,
+    pub list: i64,
+}
+
+impl Query {
+    pub fn update_access_token(
+        self,
+        token: Option<String>,
+    ) -> Result<Self, warp::reject::Rejection> {
+        match token {
+            Some(token) => Ok(Self {
+                access_token: Some(token),
+                ..self
+            }),
+            None => Ok(self),
+        }
+    }
+}
+
+macro_rules! make_query_type {
     ($name:tt => $parameter:tt:$type:tt) => {
         #[derive(Deserialize, Debug, Default)]
         pub struct $name {
@@ -19,16 +43,16 @@ macro_rules! query {
         }
     };
 }
-query!(Media => only_media:String);
+make_query_type!(Media => only_media:String);
 impl Media {
     pub fn is_truthy(&self) -> bool {
         self.only_media == "true" || self.only_media == "1"
     }
 }
-query!(Hashtag => tag: String);
-query!(List => list: i64);
-query!(Auth => access_token: String);
-query!(Stream => stream: String);
+make_query_type!(Hashtag => tag: String);
+make_query_type!(List => list: i64);
+make_query_type!(Auth => access_token: String);
+make_query_type!(Stream => stream: String);
 impl ToString for Stream {
     fn to_string(&self) -> String {
         format!("{:?}", self)
@@ -42,4 +66,20 @@ pub fn optional_media_query() -> BoxedFilter<(Media,)> {
         }))
         .unify()
         .boxed()
+}
+
+pub struct OptionalAccessToken;
+
+impl OptionalAccessToken {
+    pub fn from_header() -> warp::filters::BoxedFilter<(Option<String>,)> {
+        let from_header = warp::header::header::<String>("authorization").map(|auth: String| {
+            match auth.split(' ').nth(1) {
+                Some(s) => Some(s.to_string()),
+                None => None,
+            }
+        });
+        let no_token = warp::any().map(|| None);
+
+        from_header.or(no_token).unify().boxed()
+    }
 }

--- a/src/parse_client_request/query.rs
+++ b/src/parse_client_request/query.rs
@@ -28,7 +28,7 @@ impl Query {
 }
 
 macro_rules! make_query_type {
-    ($name:tt => $parameter:tt:$type:tt) => {
+    ($name:tt => $parameter:tt:$type:ty) => {
         #[derive(Deserialize, Debug, Default)]
         pub struct $name {
             pub $parameter: $type,
@@ -51,7 +51,7 @@ impl Media {
 }
 make_query_type!(Hashtag => tag: String);
 make_query_type!(List => list: i64);
-make_query_type!(Auth => access_token: String);
+make_query_type!(Auth => access_token: Option<String>);
 make_query_type!(Stream => stream: String);
 impl ToString for Stream {
     fn to_string(&self) -> String {

--- a/src/parse_client_request/sse.rs
+++ b/src/parse_client_request/sse.rs
@@ -1,9 +1,9 @@
 //! Filters for all the endpoints accessible for Server Sent Event updates
 use super::{
     query,
-    user::{Filter::*, OptionalAccessToken, User},
+    user::{OptionalAccessToken, User},
+    Query,
 };
-use crate::config::CustomError;
 use warp::{filters::BoxedFilter, path, Filter};
 
 #[allow(dead_code)]
@@ -12,93 +12,78 @@ type TimelineUser = ((String, User),);
 /// Helper macro to match on the first of any of the provided filters
 macro_rules! any_of {
     ($filter:expr, $($other_filter:expr),*) => {
-        $filter$(.or($other_filter).unify())*
+        $filter$(.or($other_filter).unify())*.boxed()
     };
 }
 
-pub fn filter_incomming_request() -> BoxedFilter<(String, User)> {
+macro_rules! parse_query {
+    (path => $start:tt $(/ $next:tt)*
+     endpoint => $endpoint:expr) => {
+        path!($start $(/ $next)*)
+            .and(query::Auth::to_filter())
+            .and(query::Media::to_filter())
+            .and(query::Hashtag::to_filter())
+            .and(query::List::to_filter())
+            .map(
+                |auth: query::Auth,
+                 media: query::Media,
+                 hashtag: query::Hashtag,
+                list: query::List| {
+                    let access_token = match auth.access_token.len() {
+                        0 => None,
+                        _ => Some(auth.access_token),
+                    };
+                    let query = Query {
+                        access_token,
+                        stream: $endpoint.to_string(),
+                        media: media.is_truthy(),
+                        hashtag: hashtag.tag,
+                        list: list.list,
+                    };
+                    query
+                },
+
+            )
+            .boxed()
+
+    };
+}
+pub fn extract_user_or_reject() -> BoxedFilter<(User,)> {
     any_of!(
-        path!("api" / "v1" / "streaming" / "user" / "notification")
-            .and(OptionalAccessToken::from_header_or_query())
-            .and_then(User::from_access_token_or_reject)
-            .map(|user: User| (user.id.to_string(), user.set_filter(Notification))),
-        // **NOTE**: This endpoint was present in the node.js server, but not in the
-        // [public API docs](https://docs.joinmastodon.org/api/streaming/#get-api-v1-streaming-public-local).
-        // Should it be publicly documented?
-        path!("api" / "v1" / "streaming" / "user")
-            .and(OptionalAccessToken::from_header_or_query())
-            .and_then(User::from_access_token_or_reject)
-            .map(|user: User| (user.id.to_string(), user)),
-        path!("api" / "v1" / "streaming" / "public" / "local")
-            .and(OptionalAccessToken::from_header_or_query())
-            .and_then(User::from_access_token_or_public_user)
-            .and(warp::query())
-            .map(|user: User, q: query::Media| match q.only_media.as_ref() {
-                "1" | "true" => ("public:local:media".to_owned(), user.set_filter(Language)),
-                _ => ("public:local".to_owned(), user.set_filter(Language)),
-            }),
-        path!("api" / "v1" / "streaming" / "public")
-            .and(OptionalAccessToken::from_header_or_query())
-            .and_then(User::from_access_token_or_public_user)
-            .and(warp::query())
-            .map(|user: User, q: query::Media| match q.only_media.as_ref() {
-                "1" | "true" => ("public:media".to_owned(), user.set_filter(Language)),
-                _ => ("public".to_owned(), user.set_filter(Language)),
-            }),
-        path!("api" / "v1" / "streaming" / "public" / "local")
-            .and(OptionalAccessToken::from_header_or_query())
-            .and_then(User::from_access_token_or_public_user)
-            .map(|user: User| ("public:local".to_owned(), user.set_filter(Language))),
-        path!("api" / "v1" / "streaming" / "public")
-            .and(OptionalAccessToken::from_header_or_query())
-            .and_then(User::from_access_token_or_public_user)
-            .map(|user: User| ("public".to_owned(), user.set_filter(Language))),
-        path!("api" / "v1" / "streaming" / "direct")
-            .and(OptionalAccessToken::from_header_or_query())
-            .and_then(User::from_access_token_or_reject)
-            .map(|user: User| (format!("direct:{}", user.id), user.set_filter(NoFilter))),
-        // **Note**: Hashtags are *not* filtered on language, right?
-        path!("api" / "v1" / "streaming" / "hashtag" / "local")
-            .and(OptionalAccessToken::from_header_or_query())
-            .and_then(User::from_access_token_or_public_user)
-            .and(warp::query())
-            .map(|_, q: query::Hashtag| (format!("hashtag:{}:local", q.tag), User::public())),
-        path!("api" / "v1" / "streaming" / "hashtag")
-            .and(OptionalAccessToken::from_header_or_query())
-            .and_then(User::from_access_token_or_public_user)
-            .and(warp::query())
-            .map(|_, q: query::Hashtag| (format!("hashtag:{}", q.tag), User::public())),
-        path!("api" / "v1" / "streaming" / "list")
-            .and(OptionalAccessToken::from_header_or_query())
-            .and_then(User::from_access_token_or_reject)
-            .and(warp::query())
-            .and_then(|user: User, q: query::List| {
-                if user.owns_list(q.list) {
-                    (Ok(q.list), Ok(user))
-                } else {
-                    (Err(CustomError::unauthorized_list()), Ok(user))
-                }
-            })
-            .untuple_one()
-            .map(|list: i64, user: User| (format!("list:{}", list), user.set_filter(NoFilter)))
+        parse_query!(
+            path => "api" / "v1" / "streaming" / "user" / "notification"
+            endpoint => "user:notification" ),
+        parse_query!(
+            path => "api" / "v1" / "streaming" / "user"
+            endpoint => "user"),
+        parse_query!(
+            path => "api" / "v1" / "streaming" / "public" / "local"
+            endpoint => "public:local"),
+        parse_query!(
+            path => "api" / "v1" / "streaming" / "public"
+            endpoint => "public"),
+        parse_query!(
+            path => "api" / "v1" / "streaming" / "direct"
+            endpoint => "direct"),
+        parse_query!(path => "api" / "v1" / "streaming" / "hashtag" / "local"
+                     endpoint => "hashtag:local"),
+        parse_query!(path => "api" / "v1" / "streaming" / "hashtag"
+                     endpoint => "hashtag"),
+        parse_query!(path => "api" / "v1" / "streaming" / "list"
+                endpoint => "list")
     )
-    .untuple_one()
+    // because SSE requests place their `access_token` in the header instead of in a query
+    // parameter, we need to update our Query if the header has a token
+    .and(OptionalAccessToken::from_header())
+    .and_then(Query::update_access_token)
+    .and_then(User::from_query)
     .boxed()
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-
-    struct TestUser;
-    impl TestUser {
-        fn logged_in() -> User {
-            User::from_access_token_or_reject(Some("TEST_USER".to_string())).expect("in test")
-        }
-        fn public() -> User {
-            User::from_access_token_or_public_user(None).expect("in test")
-        }
-    }
+    use crate::parse_client_request::user::{Filter, OauthScope};
 
     macro_rules! test_public_endpoint {
         ($name:ident {
@@ -108,11 +93,10 @@ mod test {
         }) => {
             #[test]
             fn $name() {
-                let (timeline, user) = warp::test::request()
+                let user = warp::test::request()
                     .path($path)
-                    .filter(&filter_incomming_request())
+                    .filter(&extract_user_or_reject())
                     .expect("in test");
-                assert_eq!(&timeline, $timeline);
                 assert_eq!(user, $user);
             }
         };
@@ -129,18 +113,16 @@ mod test {
             fn $name() {
                 let  path = format!("{}?access_token=TEST_USER", $path);
                 $(let path = format!("{}&{}", path, $query);)*
-                    let (timeline, user) = warp::test::request()
+                    let  user = warp::test::request()
                     .path(&path)
-                    .filter(&filter_incomming_request())
+                    .filter(&extract_user_or_reject())
                     .expect("in test");
-                assert_eq!(&timeline, $timeline);
                 assert_eq!(user, $user);
-                let (timeline, user) = warp::test::request()
+                let user = warp::test::request()
                     .path(&path)
                     .header("Authorization", "Bearer: TEST_USER")
-                    .filter(&filter_incomming_request())
+                    .filter(&extract_user_or_reject())
                     .expect("in test");
-                assert_eq!(&timeline, $timeline);
                 assert_eq!(user, $user);
             }
         };
@@ -160,7 +142,7 @@ mod test {
                     dbg!(&path);
                     warp::test::request()
                         .path(&path)
-                        .filter(&filter_incomming_request())
+                        .filter(&extract_user_or_reject())
                         .expect("in test");
             }
         };
@@ -180,7 +162,7 @@ mod test {
                     warp::test::request()
                     .path(&path)
                     .header("Authorization", "Bearer: INVALID")
-                    .filter(&filter_incomming_request())
+                    .filter(&extract_user_or_reject())
                     .expect("in test");
             }
         };
@@ -197,7 +179,7 @@ mod test {
                 $(let path = format!("{}?{}", path, $query);)*
                 warp::test::request()
                     .path(&path)
-                    .filter(&filter_incomming_request())
+                    .filter(&extract_user_or_reject())
                     .expect("in test");
             }
         };
@@ -206,12 +188,207 @@ mod test {
     test_public_endpoint!(public_media_true {
         endpoint: "/api/v1/streaming/public?only_media=true",
         timeline: "public:media",
-        user: TestUser::public().set_filter(Language),
+        user: User {
+            target_timeline: "public:media".to_string(),
+            id: -1,
+            access_token: "no access token".to_string(),
+            langs: None,
+            scopes: OauthScope {
+                all: false,
+                statuses: false,
+                notify: false,
+                lists: false,
+            },
+            logged_in: false,
+            filter: Filter::Language,
+        },
     });
     test_public_endpoint!(public_media_1 {
         endpoint: "/api/v1/streaming/public?only_media=1",
         timeline: "public:media",
-        user: TestUser::public().set_filter(Language),
+        user: User {
+            target_timeline: "public:media".to_string(),
+            id: -1,
+            access_token: "no access token".to_string(),
+            langs: None,
+            scopes: OauthScope {
+                all: false,
+                statuses: false,
+                notify: false,
+                lists: false,
+            },
+            logged_in: false,
+            filter: Filter::Language,
+        },
+    });
+
+    test_public_endpoint!(public_local {
+        endpoint: "/api/v1/streaming/public/local",
+        timeline: "public:local",
+        user: User {
+            target_timeline: "public:local".to_string(),
+            id: -1,
+            access_token: "no access token".to_string(),
+            langs: None,
+            scopes: OauthScope {
+                all: false,
+                statuses: false,
+                notify: false,
+                lists: false,
+            },
+            logged_in: false,
+            filter: Filter::Language,
+        },
+    });
+
+    test_public_endpoint!(public_local_media_true {
+        endpoint: "/api/v1/streaming/public/local?only_media=true",
+        timeline: "public:local:media",
+        user: User {
+            target_timeline: "public:local:media".to_string(),
+            id: -1,
+            access_token: "no access token".to_string(),
+            langs: None,
+            scopes: OauthScope {
+                all: false,
+                statuses: false,
+                notify: false,
+                lists: false,
+            },
+            logged_in: false,
+            filter: Filter::Language,
+        },
+    });
+    test_public_endpoint!(public_local_media_1 {
+        endpoint: "/api/v1/streaming/public/local?only_media=1",
+        timeline: "public:local:media",
+        user: User {
+            target_timeline: "public:local:media".to_string(),
+            id: -1,
+            access_token: "no access token".to_string(),
+            langs: None,
+            scopes: OauthScope {
+                all: false,
+                statuses: false,
+                notify: false,
+                lists: false,
+            },
+            logged_in: false,
+            filter: Filter::Language,
+        },
+    });
+    test_public_endpoint!(hashtag {
+        endpoint: "/api/v1/streaming/hashtag?tag=a",
+        timeline: "hashtag:a",
+        user: User {
+            target_timeline: "hashtag:a".to_string(),
+            id: -1,
+            access_token: "no access token".to_string(),
+            langs: None,
+            scopes: OauthScope {
+                all: false,
+                statuses: false,
+                notify: false,
+                lists: false,
+            },
+            logged_in: false,
+            filter: Filter::Language,
+        },
+    });
+    test_public_endpoint!(hashtag_local {
+        endpoint: "/api/v1/streaming/hashtag/local?tag=a",
+        timeline: "hashtag:local:a",
+        user: User {
+            target_timeline: "hashtag:local:a".to_string(),
+            id: -1,
+            access_token: "no access token".to_string(),
+            langs: None,
+            scopes: OauthScope {
+                all: false,
+                statuses: false,
+                notify: false,
+                lists: false,
+            },
+            logged_in: false,
+            filter: Filter::Language,
+        },
+    });
+
+    test_private_endpoint!(user {
+        endpoint: "/api/v1/streaming/user",
+        timeline: "1",
+        user: User {
+            target_timeline: "1".to_string(),
+            id: 1,
+            access_token: "TEST_USER".to_string(),
+            langs: None,
+            scopes: OauthScope {
+                all: true,
+                statuses: false,
+                notify: false,
+                lists: false,
+            },
+            logged_in: true,
+            filter: Filter::NoFilter,
+        },
+    });
+
+    test_private_endpoint!(user_notification {
+        endpoint: "/api/v1/streaming/user/notification",
+        timeline: "1",
+        user: User {
+            target_timeline: "1".to_string(),
+            id: 1,
+            access_token: "TEST_USER".to_string(),
+            langs: None,
+            scopes: OauthScope {
+                all: true,
+                statuses: false,
+                notify: false,
+                lists: false,
+            },
+            logged_in: true,
+            filter: Filter::Notification,
+        },
+    });
+
+    test_private_endpoint!(direct {
+        endpoint: "/api/v1/streaming/direct",
+        timeline: "direct",
+        user: User {
+            target_timeline: "direct".to_string(),
+            id: 1,
+            access_token: "TEST_USER".to_string(),
+            langs: None,
+            scopes: OauthScope {
+                all: true,
+                statuses: false,
+                notify: false,
+                lists: false,
+            },
+            logged_in: true,
+            filter: Filter::NoFilter,
+        },
+    });
+
+    test_private_endpoint!(list_valid_list {
+        endpoint: "/api/v1/streaming/list",
+        query: "list=1",
+        timeline: "list:1",
+        user: User {
+            target_timeline: "list:1".to_string(),
+            id: 1,
+            access_token: "TEST_USER".to_string(),
+            langs: None,
+            scopes: OauthScope {
+                all: true,
+                statuses: false,
+                notify: false,
+                lists: false,
+            },
+            logged_in: true,
+            filter: Filter::NoFilter,
+        },
     });
     test_bad_auth_token_in_query!(public_media_true_bad_auth {
         endpoint: "/api/v1/streaming/public",
@@ -221,12 +398,6 @@ mod test {
         endpoint: "/api/v1/streaming/public",
         query: "only_media=1",
     });
-
-    test_public_endpoint!(public_local {
-        endpoint: "/api/v1/streaming/public/local",
-        timeline: "public:local",
-        user: TestUser::public().set_filter(Language),
-    });
     test_bad_auth_token_in_query!(public_local_bad_auth_in_query {
         endpoint: "/api/v1/streaming/public/local",
     });
@@ -234,16 +405,6 @@ mod test {
         endpoint: "/api/v1/streaming/public/local",
     });
 
-    test_public_endpoint!(public_local_media_true {
-        endpoint: "/api/v1/streaming/public/local?only_media=true",
-        timeline: "public:local:media",
-        user: TestUser::public().set_filter(Language),
-    });
-    test_public_endpoint!(public_local_media_1 {
-        endpoint: "/api/v1/streaming/public/local?only_media=1",
-        timeline: "public:local:media",
-        user: TestUser::public().set_filter(Language),
-    });
     test_bad_auth_token_in_query!(public_local_media_timeline_bad_auth_in_query {
         endpoint: "/api/v1/streaming/public/local",
         query: "only_media=1",
@@ -251,12 +412,6 @@ mod test {
     test_bad_auth_token_in_header!(public_local_media_timeline_bad_token_in_header {
         endpoint: "/api/v1/streaming/public/local",
         query: "only_media=true",
-    });
-
-    test_public_endpoint!(hashtag {
-        endpoint: "/api/v1/streaming/hashtag?tag=a",
-        timeline: "hashtag:a",
-        user: TestUser::public(),
     });
     test_bad_auth_token_in_query!(hashtag_bad_auth_in_query {
         endpoint: "/api/v1/streaming/hashtag",
@@ -267,25 +422,6 @@ mod test {
         query: "tag=a",
     });
 
-    test_public_endpoint!(hashtag_local {
-        endpoint: "/api/v1/streaming/hashtag/local?tag=a",
-        timeline: "hashtag:a:local",
-        user: TestUser::public(),
-    });
-    test_bad_auth_token_in_query!(hashtag_local_bad_auth_in_query {
-        endpoint: "/api/v1/streaming/hashtag/local",
-        query: "tag=a",
-    });
-    test_bad_auth_token_in_header!(hashtag_local_bad_auth_in_header {
-        endpoint: "/api/v1/streaming/hashtag/local",
-        query: "tag=a",
-    });
-
-    test_private_endpoint!(user {
-        endpoint: "/api/v1/streaming/user",
-        timeline: "1",
-        user: TestUser::logged_in(),
-    });
     test_bad_auth_token_in_query!(user_bad_auth_in_query {
         endpoint: "/api/v1/streaming/user",
     });
@@ -296,11 +432,6 @@ mod test {
         endpoint: "/api/v1/streaming/user",
     });
 
-    test_private_endpoint!(user_notification {
-        endpoint: "/api/v1/streaming/user/notification",
-        timeline: "1",
-        user: TestUser::logged_in().set_filter(Notification),
-    });
     test_bad_auth_token_in_query!(user_notification_bad_auth_in_query {
         endpoint: "/api/v1/streaming/user/notification",
     });
@@ -311,11 +442,6 @@ mod test {
         endpoint: "/api/v1/streaming/user/notification",
     });
 
-    test_private_endpoint!(direct {
-        endpoint: "/api/v1/streaming/direct",
-        timeline: "direct:1",
-        user: TestUser::logged_in(),
-    });
     test_bad_auth_token_in_query!(direct_bad_auth_in_query {
         endpoint: "/api/v1/streaming/direct",
     });
@@ -326,12 +452,6 @@ mod test {
         endpoint: "/api/v1/streaming/direct",
     });
 
-    test_private_endpoint!(list_valid_list {
-        endpoint: "/api/v1/streaming/list",
-        query: "list=1",
-        timeline: "list:1",
-        user: TestUser::logged_in(),
-    });
     test_bad_auth_token_in_query!(list_bad_auth_in_query {
         endpoint: "/api/v1/streaming/list",
         query: "list=1",

--- a/src/parse_client_request/sse.rs
+++ b/src/parse_client_request/sse.rs
@@ -24,24 +24,17 @@ macro_rules! parse_query {
                 |auth: query::Auth,
                  media: query::Media,
                  hashtag: query::Hashtag,
-                list: query::List| {
-                    let access_token = match auth.access_token.len() {
-                        0 => None,
-                        _ => Some(auth.access_token),
-                    };
-                    let query = Query {
-                        access_token,
+                 list: query::List| {
+                    Query {
+                        access_token: auth.access_token,
                         stream: $endpoint.to_string(),
                         media: media.is_truthy(),
                         hashtag: hashtag.tag,
                         list: list.list,
-                    };
-                    query
-                },
-
+                    }
+                 },
             )
             .boxed()
-
     };
 }
 pub fn extract_user_or_reject() -> BoxedFilter<(User,)> {

--- a/src/parse_client_request/sse.rs
+++ b/src/parse_client_request/sse.rs
@@ -1,9 +1,5 @@
 //! Filters for all the endpoints accessible for Server Sent Event updates
-use super::{
-    query,
-    user::{OptionalAccessToken, User},
-    Query,
-};
+use super::{query, query::Query, user::User};
 use warp::{filters::BoxedFilter, path, Filter};
 
 #[allow(dead_code)]
@@ -74,7 +70,7 @@ pub fn extract_user_or_reject() -> BoxedFilter<(User,)> {
     )
     // because SSE requests place their `access_token` in the header instead of in a query
     // parameter, we need to update our Query if the header has a token
-    .and(OptionalAccessToken::from_header())
+    .and(query::OptionalAccessToken::from_header())
     .and_then(Query::update_access_token)
     .and_then(User::from_query)
     .boxed()
@@ -88,7 +84,6 @@ mod test {
     macro_rules! test_public_endpoint {
         ($name:ident {
             endpoint: $path:expr,
-            timeline: $timeline:expr,
             user: $user:expr,
         }) => {
             #[test]
@@ -106,7 +101,6 @@ mod test {
         ($name:ident {
             endpoint: $path:expr,
             $(query: $query:expr,)*
-            timeline: $timeline:expr,
             user: $user:expr,
         }) => {
             #[test]
@@ -187,7 +181,6 @@ mod test {
 
     test_public_endpoint!(public_media_true {
         endpoint: "/api/v1/streaming/public?only_media=true",
-        timeline: "public:media",
         user: User {
             target_timeline: "public:media".to_string(),
             id: -1,
@@ -205,7 +198,6 @@ mod test {
     });
     test_public_endpoint!(public_media_1 {
         endpoint: "/api/v1/streaming/public?only_media=1",
-        timeline: "public:media",
         user: User {
             target_timeline: "public:media".to_string(),
             id: -1,
@@ -224,7 +216,6 @@ mod test {
 
     test_public_endpoint!(public_local {
         endpoint: "/api/v1/streaming/public/local",
-        timeline: "public:local",
         user: User {
             target_timeline: "public:local".to_string(),
             id: -1,
@@ -243,7 +234,6 @@ mod test {
 
     test_public_endpoint!(public_local_media_true {
         endpoint: "/api/v1/streaming/public/local?only_media=true",
-        timeline: "public:local:media",
         user: User {
             target_timeline: "public:local:media".to_string(),
             id: -1,
@@ -261,7 +251,6 @@ mod test {
     });
     test_public_endpoint!(public_local_media_1 {
         endpoint: "/api/v1/streaming/public/local?only_media=1",
-        timeline: "public:local:media",
         user: User {
             target_timeline: "public:local:media".to_string(),
             id: -1,
@@ -279,7 +268,6 @@ mod test {
     });
     test_public_endpoint!(hashtag {
         endpoint: "/api/v1/streaming/hashtag?tag=a",
-        timeline: "hashtag:a",
         user: User {
             target_timeline: "hashtag:a".to_string(),
             id: -1,
@@ -297,7 +285,6 @@ mod test {
     });
     test_public_endpoint!(hashtag_local {
         endpoint: "/api/v1/streaming/hashtag/local?tag=a",
-        timeline: "hashtag:local:a",
         user: User {
             target_timeline: "hashtag:local:a".to_string(),
             id: -1,
@@ -316,7 +303,6 @@ mod test {
 
     test_private_endpoint!(user {
         endpoint: "/api/v1/streaming/user",
-        timeline: "1",
         user: User {
             target_timeline: "1".to_string(),
             id: 1,
@@ -335,7 +321,6 @@ mod test {
 
     test_private_endpoint!(user_notification {
         endpoint: "/api/v1/streaming/user/notification",
-        timeline: "1",
         user: User {
             target_timeline: "1".to_string(),
             id: 1,
@@ -354,7 +339,6 @@ mod test {
 
     test_private_endpoint!(direct {
         endpoint: "/api/v1/streaming/direct",
-        timeline: "direct",
         user: User {
             target_timeline: "direct".to_string(),
             id: 1,
@@ -374,7 +358,6 @@ mod test {
     test_private_endpoint!(list_valid_list {
         endpoint: "/api/v1/streaming/list",
         query: "list=1",
-        timeline: "list:1",
         user: User {
             target_timeline: "list:1".to_string(),
             id: 1,

--- a/src/parse_client_request/sse.rs
+++ b/src/parse_client_request/sse.rs
@@ -96,7 +96,6 @@ mod test {
             }
         };
     }
-
     macro_rules! test_private_endpoint {
         ($name:ident {
             endpoint: $path:expr,
@@ -121,7 +120,6 @@ mod test {
             }
         };
     }
-
     macro_rules! test_bad_auth_token_in_query {
         ($name: ident {
             endpoint: $path:expr,
@@ -129,7 +127,6 @@ mod test {
         }) => {
             #[test]
             #[should_panic(expected = "Error: Invalid access token")]
-
             fn $name() {
                 let  path = format!("{}?access_token=INVALID", $path);
                 $(let path = format!("{}&{}", path, $query);)*
@@ -141,7 +138,6 @@ mod test {
             }
         };
     }
-
     macro_rules! test_bad_auth_token_in_header {
         ($name: ident {
             endpoint: $path:expr,
@@ -213,7 +209,6 @@ mod test {
             filter: Filter::Language,
         },
     });
-
     test_public_endpoint!(public_local {
         endpoint: "/api/v1/streaming/public/local",
         user: User {
@@ -231,7 +226,6 @@ mod test {
             filter: Filter::Language,
         },
     });
-
     test_public_endpoint!(public_local_media_true {
         endpoint: "/api/v1/streaming/public/local?only_media=true",
         user: User {
@@ -318,7 +312,6 @@ mod test {
             filter: Filter::NoFilter,
         },
     });
-
     test_private_endpoint!(user_notification {
         endpoint: "/api/v1/streaming/user/notification",
         user: User {
@@ -336,7 +329,6 @@ mod test {
             filter: Filter::Notification,
         },
     });
-
     test_private_endpoint!(direct {
         endpoint: "/api/v1/streaming/direct",
         user: User {
@@ -387,7 +379,6 @@ mod test {
     test_bad_auth_token_in_header!(public_local_bad_auth_in_header {
         endpoint: "/api/v1/streaming/public/local",
     });
-
     test_bad_auth_token_in_query!(public_local_media_timeline_bad_auth_in_query {
         endpoint: "/api/v1/streaming/public/local",
         query: "only_media=1",
@@ -404,7 +395,6 @@ mod test {
         endpoint: "/api/v1/streaming/hashtag",
         query: "tag=a",
     });
-
     test_bad_auth_token_in_query!(user_bad_auth_in_query {
         endpoint: "/api/v1/streaming/user",
     });
@@ -414,7 +404,6 @@ mod test {
     test_missing_auth!(user_missing_auth_token {
         endpoint: "/api/v1/streaming/user",
     });
-
     test_bad_auth_token_in_query!(user_notification_bad_auth_in_query {
         endpoint: "/api/v1/streaming/user/notification",
     });
@@ -424,7 +413,6 @@ mod test {
     test_missing_auth!(user_notification_missing_auth_token {
         endpoint: "/api/v1/streaming/user/notification",
     });
-
     test_bad_auth_token_in_query!(direct_bad_auth_in_query {
         endpoint: "/api/v1/streaming/direct",
     });
@@ -434,7 +422,6 @@ mod test {
     test_missing_auth!(direct_missing_auth_token {
         endpoint: "/api/v1/streaming/direct",
     });
-
     test_bad_auth_token_in_query!(list_bad_auth_in_query {
         endpoint: "/api/v1/streaming/list",
         query: "list=1",
@@ -447,5 +434,14 @@ mod test {
         endpoint: "/api/v1/streaming/list",
         query: "list=1",
     });
+
+    #[test]
+    #[should_panic(expected = "NotFound")]
+    fn nonexistant_endpoint() {
+        warp::test::request()
+            .path("/api/v1/streaming/DOES_NOT_EXIST")
+            .filter(&extract_user_or_reject())
+            .expect("in test");
+    }
 
 }

--- a/src/parse_client_request/ws.rs
+++ b/src/parse_client_request/ws.rs
@@ -1,43 +1,361 @@
 //! Filters for the WebSocket endpoint
 use super::{
     query,
-    user::{Scope, User},
+    user::{OptionalAccessToken, Scope, User},
+    Query,
 };
 use crate::user_from_path;
 use warp::{filters::BoxedFilter, path, Filter};
 
 /// WebSocket filters
-pub fn extract_user_and_query() -> BoxedFilter<(User, Query, warp::ws::Ws2)> {
-    user_from_path!("streaming", Scope::Public)
+pub fn parse_query() -> BoxedFilter<(Query,)> {
+    path!("api" / "v1" / "streaming")
         .and(warp::query())
+        .and(query::Auth::to_filter())
         .and(query::Media::to_filter())
         .and(query::Hashtag::to_filter())
         .and(query::List::to_filter())
-        .and(warp::ws2())
         .map(
-            |user: User,
-             stream: query::Stream,
+            |stream: query::Stream,
+             auth: query::Auth,
              media: query::Media,
              hashtag: query::Hashtag,
-             list: query::List,
-             ws: warp::ws::Ws2| {
+             list: query::List| {
                 let query = Query {
+                    access_token: Some(auth.access_token),
                     stream: stream.stream,
                     media: media.is_truthy(),
                     hashtag: hashtag.tag,
                     list: list.list,
                 };
-                (user, query, ws)
+                query
             },
         )
-        .untuple_one()
         .boxed()
 }
 
-#[derive(Debug)]
-pub struct Query {
-    pub stream: String,
-    pub media: bool,
-    pub hashtag: String,
-    pub list: i64,
+pub fn generate_timeline_and_update_user(q: Query) -> Result<(String, User), warp::Rejection> {
+    let mut user = User::from_access_token_or_public_user(q.access_token).unwrap();
+
+    let read_scope = user.scopes.clone();
+
+    let timeline = match q.stream.as_ref() {
+        // Public endpoints:
+        tl @ "public" | tl @ "public:local" if q.media => format!("{}:media", tl),
+        tl @ "public:media" | tl @ "public:local:media" => tl.to_string(),
+        tl @ "public" | tl @ "public:local" => tl.to_string(),
+        // Hashtag endpoints:
+        tl @ "hashtag" | tl @ "hashtag:local" => format!("{}:{}", tl, q.hashtag),
+        // Private endpoints: User
+        "user" if user.logged_in && (read_scope.all || read_scope.statuses) => {
+            format!("{}", user.id)
+        }
+        "user:notification" if user.logged_in && (read_scope.all || read_scope.notify) => {
+            user = user.set_filter(super::user::Filter::Notification);
+            format!("{}", user.id)
+        }
+        // List endpoint:
+        "list" if user.owns_list(q.list) && (read_scope.all || read_scope.lists) => {
+            format!("list:{}", q.list)
+        }
+        // Direct endpoint:
+        "direct" if user.logged_in && (read_scope.all || read_scope.statuses) => {
+            "direct".to_string()
+        }
+        // Reject unathorized access attempts for private endpoints
+        "user" | "user:notification" | "direct" | "list" => {
+            return Err(warp::reject::custom("Error: Invalid Access Token"))
+        }
+        // Other endpoints don't exist:
+        _ => return Err(warp::reject::custom("Error: Nonexistent WebSocket query")),
+    };
+    user.target_timeline = timeline.clone();
+    Ok::<_, warp::Rejection>((timeline, user))
 }
+
+// #[cfg(false)]
+// mod test {
+//     use super::*;
+
+//     struct TestUser;
+//     impl TestUser {
+//         fn logged_in() -> User {
+//             User::from_access_token_or_reject(Some("TEST_USER".to_string())).expect("in test")
+//         }
+//         fn public() -> User {
+
+//         }
+//     }
+
+//     Macro_rules! test_public_endpoint {
+//         ($name:ident {
+//             raw_query: $raw_query:expr,
+//             parsed_query: $parsed_query:expr,
+//         }) => {
+//             #[test]
+//             fn $name() {
+//                 let (user, parsed_query, _) = warp::test::request()
+//                     .path(&format!("/api/v1/streaming?{}", $raw_query))
+//                     .header("connection", "upgrade")
+//                     .header("upgrade", "websocket")
+//                     .header("sec-websocket-version", "13")
+//                     .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+//                     .filter(&extract_user_and_query())
+//                     .expect("in test");
+
+//                 assert_eq!(parsed_query.stream, $parsed_query.stream);
+//                 assert_eq!(parsed_query.media, $parsed_query.media);
+//                 assert_eq!(parsed_query.hashtag, $parsed_query.hashtag);
+//                 assert_eq!(parsed_query.list, $parsed_query.list);
+//                 assert_eq!(user, TestUser::public());
+//             }
+//         };
+//     }
+//     macro_rules! test_private_endpoint {
+//         ($name:ident {
+//             raw_query: $raw_query:expr,
+//             parsed_query: $parsed_query:expr,
+//             user: $user:expr,
+//         }) => {
+//             #[test]
+//             fn $name() {
+//                 let (user, parsed_query, _) = warp::test::request()
+//                     .path(&format!(
+//                         "/api/v1/streaming?access_token=TEST_USER&{}",
+//                         $raw_query
+//                     ))
+//                     .header("connection", "upgrade")
+//                     .header("upgrade", "websocket")
+//                     .header("sec-websocket-version", "13")
+//                     .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+//                     .filter(&extract_user_and_query())
+//                     .expect("in test");
+
+//                 assert_eq!(parsed_query.stream, $parsed_query.stream);
+//                 assert_eq!(parsed_query.media, $parsed_query.media);
+//                 assert_eq!(parsed_query.hashtag, $parsed_query.hashtag);
+//                 assert_eq!(parsed_query.list, $parsed_query.list);
+//                 assert_eq!(user, $user);
+//             }
+//         };
+//     }
+
+//     // macro_rules! test_private_endpoint {
+//     //     ($name:ident {
+//     //         endpoint: $path:expr,
+//     //         $(query: $query:expr,)*
+//     //         timeline: $timeline:expr,
+//     //         user: $user:expr,
+//     //     }) => {
+//     //         #[test]
+//     //         fn $name() {
+//     //             let  path = format!("{}?access_token=TEST_USER", $path);
+//     //             $(let path = format!("{}&{}", path, $query);)*
+//     //                 let (timeline, user) = warp::test::request()
+//     //                 .path(&path)
+//     //                 .filter(&filter_incomming_request())
+//     //                 .expect("in test");
+//     //             assert_eq!(&timeline, $timeline);
+//     //             assert_eq!(user, $user);
+//     //             let (timeline, user) = warp::test::request()
+//     //                 .path(&path)
+//     //                 .header("Authorization", "Bearer: TEST_USER")
+//     //                 .filter(&filter_incomming_request())
+//     //                 .expect("in test");
+//     //             assert_eq!(&timeline, $timeline);
+//     //             assert_eq!(user, $user);
+//     //         }
+//     //     };
+//     // }
+
+//     //         $(query: $query:expr,)*
+//     //     }) => {
+//     //         #[test]
+//     //         #[should_panic(expected = "Error: Missing access token")]
+//     //         fn $name() {
+//     //             let path = $path;
+//     //             $(let path = format!("{}?{}", path, $query);)*
+//     //             warp::test::request()
+//     //                 .path(&path)
+//     //                 .filter(&filter_incomming_request())
+//     //                 .expect("in test");
+//     //         }
+//     //     };
+//     // }
+
+//     #[test]
+//     #[should_panic(expected = "Error: Invalid access token")]
+//     fn bad_auth_token() {
+//         warp::test::request()
+//             .path("/api/v1/streaming?stream=public&access_token=INVALID")
+//             .header("connection", "upgrade")
+//             .header("upgrade", "websocket")
+//             .header("sec-websocket-version", "13")
+//             .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+//             .filter(&extract_user_and_query())
+//             .expect("to panic");
+//     }
+
+//     test_public_endpoint!(public_media_true {
+//         raw_query: "stream=public&only_media=true",
+//         parsed_query: Query {
+//             stream: "public".to_string(),
+//             media: true,
+//             hashtag: String::new(),
+//             list: 0,
+//         },
+//     });
+//     test_public_endpoint!(public_media_1 {
+//         raw_query: "stream=public&only_media=1",
+//         parsed_query: Query {
+//             stream: "public".to_string(),
+//             media: true,
+//             hashtag: String::new(),
+//             list: 0,
+//         },
+//     });
+//     test_private_endpoint!(user {
+//         raw_query: "stream=user",
+//         parsed_query: Query {
+//             stream: "user".to_string(),
+//             media: false,
+//             hashtag: String::new(),
+//             list: 0,
+//         },
+//         user: TestUser::logged_in(),
+//     });
+
+//     //     test_bad_auth_token_in_query!(public_media_true_bad_auth {
+//     //         endpoint: "/api/v1/streaming/public",
+
+//     //         query: "only_media=true",
+//     //     });
+//     //     test_bad_auth_token_in_header!(public_media_1_bad_auth {
+//     //         endpoint: "/api/v1/streaming/public",
+//     //         query: "only_media=1",
+//     //     });
+
+//     //     test_public_endpoint!(public_local {
+//     //         endpoint: "/api/v1/streaming/public/local",
+//     //         timeline: "public:local",
+//     //         user: TestUser::public().set_filter(Language),
+//     //     });
+//     //     test_bad_auth_token_in_query!(public_local_bad_auth_in_query {
+//     //         endpoint: "/api/v1/streaming/public/local",
+//     //     });
+//     //     test_bad_auth_token_in_header!(public_local_bad_auth_in_header {
+//     //         endpoint: "/api/v1/streaming/public/local",
+//     //     });
+
+//     //     test_public_endpoint!(public_local_media_true {
+//     //         endpoint: "/api/v1/streaming/public/local?only_media=true",
+//     //         timeline: "public:local:media",
+//     //         user: TestUser::public().set_filter(Language),
+//     //     });
+//     //     test_public_endpoint!(public_local_media_1 {
+//     //         endpoint: "/api/v1/streaming/public/local?only_media=1",
+//     //         timeline: "public:local:media",
+//     //         user: TestUser::public().set_filter(Language),
+//     //     });
+//     //     test_bad_auth_token_in_query!(public_local_media_timeline_bad_auth_in_query {
+//     //         endpoint: "/api/v1/streaming/public/local",
+//     //         query: "only_media=1",
+//     //     });
+//     //     test_bad_auth_token_in_header!(public_local_media_timeline_bad_token_in_header {
+//     //         endpoint: "/api/v1/streaming/public/local",
+//     //         query: "only_media=true",
+//     //     });
+
+//     //     test_public_endpoint!(hashtag {
+//     //         endpoint: "/api/v1/streaming/hashtag?tag=a",
+//     //         timeline: "hashtag:a",
+//     //         user: TestUser::public(),
+//     //     });
+//     //     test_bad_auth_token_in_query!(hashtag_bad_auth_in_query {
+//     //         endpoint: "/api/v1/streaming/hashtag",
+//     //         query: "tag=a",
+//     //     });
+//     //     test_bad_auth_token_in_header!(hashtag_bad_auth_in_header {
+//     //         endpoint: "/api/v1/streaming/hashtag",
+//     //         query: "tag=a",
+//     //     });
+
+//     //     test_public_endpoint!(hashtag_local {
+//     //         endpoint: "/api/v1/streaming/hashtag/local?tag=a",
+//     //         timeline: "hashtag:a:local",
+//     //         user: TestUser::public(),
+//     //     });
+//     //     test_bad_auth_token_in_query!(hashtag_local_bad_auth_in_query {
+//     //         endpoint: "/api/v1/streaming/hashtag/local",
+//     //         query: "tag=a",
+//     //     });
+//     //     test_bad_auth_token_in_header!(hashtag_local_bad_auth_in_header {
+//     //         endpoint: "/api/v1/streaming/hashtag/local",
+//     //         query: "tag=a",
+//     //     });
+
+//     //     test_private_endpoint!(user {
+//     //         endpoint: "/api/v1/streaming/user",
+//     //         timeline: "1",
+//     //         user: TestUser::logged_in(),
+//     //     });
+//     //     test_bad_auth_token_in_query!(user_bad_auth_in_query {
+//     //         endpoint: "/api/v1/streaming/user",
+//     //     });
+//     //     test_bad_auth_token_in_header!(user_bad_auth_in_header {
+//     //         endpoint: "/api/v1/streaming/user",
+//     //     });
+//     //     test_missing_auth!(user_missing_auth_token {
+//     //         endpoint: "/api/v1/streaming/user",
+//     //     });
+
+//     //     test_private_endpoint!(user_notification {
+//     //         endpoint: "/api/v1/streaming/user/notification",
+//     //         timeline: "1",
+//     //         user: TestUser::logged_in().set_filter(Notification),
+//     //     });
+//     //     test_bad_auth_token_in_query!(user_notification_bad_auth_in_query {
+//     //         endpoint: "/api/v1/streaming/user/notification",
+//     //     });
+//     //     test_bad_auth_token_in_header!(user_notification_bad_auth_in_header {
+//     //         endpoint: "/api/v1/streaming/user/notification",
+//     //     });
+//     //     test_missing_auth!(user_notification_missing_auth_token {
+//     //         endpoint: "/api/v1/streaming/user/notification",
+//     //     });
+
+//     //     test_private_endpoint!(direct {
+//     //         endpoint: "/api/v1/streaming/direct",
+//     //         timeline: "direct:1",
+//     //         user: TestUser::logged_in(),
+//     //     });
+//     //     test_bad_auth_token_in_query!(direct_bad_auth_in_query {
+//     //         endpoint: "/api/v1/streaming/direct",
+//     //     });
+//     //     test_bad_auth_token_in_header!(direct_bad_auth_in_header {
+//     //         endpoint: "/api/v1/streaming/direct",
+//     //     });
+//     //     test_missing_auth!(direct_missing_auth_token {
+//     //         endpoint: "/api/v1/streaming/direct",
+//     //     });
+
+//     //     test_private_endpoint!(list_valid_list {
+//     //         endpoint: "/api/v1/streaming/list",
+//     //         query: "list=1",
+//     //         timeline: "list:1",
+//     //         user: TestUser::logged_in(),
+//     //     });
+//     //     test_bad_auth_token_in_query!(list_bad_auth_in_query {
+//     //         endpoint: "/api/v1/streaming/list",
+//     //         query: "list=1",
+//     //     });
+//     //     test_bad_auth_token_in_header!(list_bad_auth_in_header {
+//     //         endpoint: "/api/v1/streaming/list",
+//     //         query: "list=1",
+//     //     });
+//     //     test_missing_auth!(list_missing_auth_token {
+//     //         endpoint: "/api/v1/streaming/list",
+//     //         query: "list=1",
+//     //     });
+
+// }

--- a/src/parse_client_request/ws.rs
+++ b/src/parse_client_request/ws.rs
@@ -17,18 +17,13 @@ fn parse_query() -> BoxedFilter<(Query,)> {
              media: query::Media,
              hashtag: query::Hashtag,
              list: query::List| {
-                let query = Query {
-                    access_token: if auth.access_token.len() > 0 {
-                        Some(auth.access_token)
-                    } else {
-                        None
-                    },
+                Query {
+                    access_token: auth.access_token,
                     stream: stream.stream,
                     media: media.is_truthy(),
                     hashtag: hashtag.tag,
                     list: list.list,
-                };
-                query
+                }
             },
         )
         .boxed()
@@ -84,13 +79,13 @@ mod test {
     macro_rules! test_bad_auth_token_in_query {
         ($name: ident {
             endpoint: $path:expr,
-            
+
         }) => {
             #[test]
             #[should_panic(expected = "Error: Invalid access token")]
 
             fn $name() {
-                let  path = format!("{}&access_token=INVALID", $path);
+                let path = format!("{}&access_token=INVALID", $path);
                 warp::test::request()
                     .path(&path)
                     .filter(&extract_user_or_reject())
@@ -100,7 +95,7 @@ mod test {
     }
     macro_rules! test_missing_auth {
         ($name: ident {
-            endpoint: $path:expr,            
+            endpoint: $path:expr,
         }) => {
             #[test]
             #[should_panic(expected = "Error: Missing access token")]
@@ -113,7 +108,7 @@ mod test {
             }
         };
     }
-    
+
     test_public_endpoint!(public_media {
         endpoint: "/api/v1/streaming?stream=public:media",
         user: User {
@@ -199,7 +194,7 @@ mod test {
             filter: Filter::Language,
         },
     });
-    
+
     test_private_endpoint!(user {
         endpoint: "/api/v1/streaming?stream=user",
         user: User {
@@ -268,19 +263,18 @@ mod test {
             filter: Filter::NoFilter,
         },
     });
-    
+
     test_bad_auth_token_in_query!(public_media_true_bad_auth {
-        endpoint: "/api/v1/streaming?stream=public:media",        
+        endpoint: "/api/v1/streaming?stream=public:media",
     });
     test_bad_auth_token_in_query!(public_local_bad_auth_in_query {
         endpoint: "/api/v1/streaming?stream=public:local",
     });
     test_bad_auth_token_in_query!(public_local_media_timeline_bad_auth_in_query {
         endpoint: "/api/v1/streaming?stream=public:local:media",
-        
     });
     test_bad_auth_token_in_query!(hashtag_bad_auth_in_query {
-        endpoint: "/api/v1/streaming?stream=hashtag&tag=a",        
+        endpoint: "/api/v1/streaming?stream=hashtag&tag=a",
     });
     test_bad_auth_token_in_query!(user_bad_auth_in_query {
         endpoint: "/api/v1/streaming?stream=user",
@@ -301,10 +295,10 @@ mod test {
         endpoint: "/api/v1/streaming?stream=direct",
     });
     test_bad_auth_token_in_query!(list_bad_auth_in_query {
-        endpoint: "/api/v1/streaming?stream=list&list=1",        
+        endpoint: "/api/v1/streaming?stream=list&list=1",
     });
     test_missing_auth!(list_missing_auth_token {
-        endpoint: "/api/v1/streaming?stream=list&list=1",        
+        endpoint: "/api/v1/streaming?stream=list&list=1",
     });
 
     #[test]

--- a/src/parse_client_request/ws.rs
+++ b/src/parse_client_request/ws.rs
@@ -1,14 +1,9 @@
 //! Filters for the WebSocket endpoint
-use super::{
-    query,
-    user::{OptionalAccessToken, Scope, User},
-    Query,
-};
-use crate::user_from_path;
+use super::{query, query::Query, user::User};
 use warp::{filters::BoxedFilter, path, Filter};
 
 /// WebSocket filters
-pub fn parse_query() -> BoxedFilter<(Query,)> {
+fn parse_query() -> BoxedFilter<(Query,)> {
     path!("api" / "v1" / "streaming")
         .and(warp::query())
         .and(query::Auth::to_filter())
@@ -22,7 +17,11 @@ pub fn parse_query() -> BoxedFilter<(Query,)> {
              hashtag: query::Hashtag,
              list: query::List| {
                 let query = Query {
-                    access_token: Some(auth.access_token),
+                    access_token: if auth.access_token.len() > 0 {
+                        Some(auth.access_token)
+                    } else {
+                        None
+                    },
                     stream: stream.stream,
                     media: media.is_truthy(),
                     hashtag: hashtag.tag,
@@ -34,328 +33,295 @@ pub fn parse_query() -> BoxedFilter<(Query,)> {
         .boxed()
 }
 
-pub fn generate_timeline_and_update_user(q: Query) -> Result<(String, User), warp::Rejection> {
-    let mut user = User::from_access_token_or_public_user(q.access_token).unwrap();
-
-    let read_scope = user.scopes.clone();
-
-    let timeline = match q.stream.as_ref() {
-        // Public endpoints:
-        tl @ "public" | tl @ "public:local" if q.media => format!("{}:media", tl),
-        tl @ "public:media" | tl @ "public:local:media" => tl.to_string(),
-        tl @ "public" | tl @ "public:local" => tl.to_string(),
-        // Hashtag endpoints:
-        tl @ "hashtag" | tl @ "hashtag:local" => format!("{}:{}", tl, q.hashtag),
-        // Private endpoints: User
-        "user" if user.logged_in && (read_scope.all || read_scope.statuses) => {
-            format!("{}", user.id)
-        }
-        "user:notification" if user.logged_in && (read_scope.all || read_scope.notify) => {
-            user = user.set_filter(super::user::Filter::Notification);
-            format!("{}", user.id)
-        }
-        // List endpoint:
-        "list" if user.owns_list(q.list) && (read_scope.all || read_scope.lists) => {
-            format!("list:{}", q.list)
-        }
-        // Direct endpoint:
-        "direct" if user.logged_in && (read_scope.all || read_scope.statuses) => {
-            "direct".to_string()
-        }
-        // Reject unathorized access attempts for private endpoints
-        "user" | "user:notification" | "direct" | "list" => {
-            return Err(warp::reject::custom("Error: Invalid Access Token"))
-        }
-        // Other endpoints don't exist:
-        _ => return Err(warp::reject::custom("Error: Nonexistent WebSocket query")),
-    };
-    user.target_timeline = timeline.clone();
-    Ok::<_, warp::Rejection>((timeline, user))
+pub fn extract_user_or_reject() -> BoxedFilter<(User,)> {
+    parse_query().and_then(User::from_query).boxed()
 }
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::parse_client_request::user::{Filter, OauthScope};
 
-// #[cfg(false)]
-// mod test {
-//     use super::*;
+    macro_rules! test_public_endpoint {
+        ($name:ident {
+            endpoint: $path:expr,
+            user: $user:expr,
+        }) => {
+            #[test]
+            fn $name() {
+                let user = warp::test::request()
+                    .path($path)
+                    .header("connection", "upgrade")
+                    .header("upgrade", "websocket")
+                    .header("sec-websocket-version", "13")
+                    .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+                    .filter(&extract_user_or_reject())
+                    .expect("in test");
+                assert_eq!(user, $user);
+            }
+        };
+    }
 
-//     struct TestUser;
-//     impl TestUser {
-//         fn logged_in() -> User {
-//             User::from_access_token_or_reject(Some("TEST_USER".to_string())).expect("in test")
-//         }
-//         fn public() -> User {
+    macro_rules! test_private_endpoint {
+        ($name:ident {
+            endpoint: $path:expr,
+            user: $user:expr,
+        }) => {
+            #[test]
+            fn $name() {
+                let path = format!("{}&access_token=TEST_USER", $path);
+                let user = warp::test::request()
+                    .path(&path)
+                    .header("connection", "upgrade")
+                    .header("upgrade", "websocket")
+                    .header("sec-websocket-version", "13")
+                    .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+                    .filter(&extract_user_or_reject())
+                    .expect("in test");
+                assert_eq!(user, $user);
+            }
+        };
+    }
 
-//         }
-//     }
+    macro_rules! test_bad_auth_token_in_query {
+        ($name: ident {
+            endpoint: $path:expr,
+            
+        }) => {
+            #[test]
+            #[should_panic(expected = "Error: Invalid access token")]
 
-//     Macro_rules! test_public_endpoint {
-//         ($name:ident {
-//             raw_query: $raw_query:expr,
-//             parsed_query: $parsed_query:expr,
-//         }) => {
-//             #[test]
-//             fn $name() {
-//                 let (user, parsed_query, _) = warp::test::request()
-//                     .path(&format!("/api/v1/streaming?{}", $raw_query))
-//                     .header("connection", "upgrade")
-//                     .header("upgrade", "websocket")
-//                     .header("sec-websocket-version", "13")
-//                     .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
-//                     .filter(&extract_user_and_query())
-//                     .expect("in test");
+            fn $name() {
+                let  path = format!("{}&access_token=INVALID", $path);
+                warp::test::request()
+                    .path(&path)
+                    .filter(&extract_user_or_reject())
+                    .expect("in test");
+            }
+        };
+    }
 
-//                 assert_eq!(parsed_query.stream, $parsed_query.stream);
-//                 assert_eq!(parsed_query.media, $parsed_query.media);
-//                 assert_eq!(parsed_query.hashtag, $parsed_query.hashtag);
-//                 assert_eq!(parsed_query.list, $parsed_query.list);
-//                 assert_eq!(user, TestUser::public());
-//             }
-//         };
-//     }
-//     macro_rules! test_private_endpoint {
-//         ($name:ident {
-//             raw_query: $raw_query:expr,
-//             parsed_query: $parsed_query:expr,
-//             user: $user:expr,
-//         }) => {
-//             #[test]
-//             fn $name() {
-//                 let (user, parsed_query, _) = warp::test::request()
-//                     .path(&format!(
-//                         "/api/v1/streaming?access_token=TEST_USER&{}",
-//                         $raw_query
-//                     ))
-//                     .header("connection", "upgrade")
-//                     .header("upgrade", "websocket")
-//                     .header("sec-websocket-version", "13")
-//                     .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
-//                     .filter(&extract_user_and_query())
-//                     .expect("in test");
+    macro_rules! test_missing_auth {
+        ($name: ident {
+            endpoint: $path:expr,            
+        }) => {
+            #[test]
+            #[should_panic(expected = "Error: Missing access token")]
+            fn $name() {
+                let path = $path;
+                warp::test::request()
+                    .path(&path)
+                    .filter(&extract_user_or_reject())
+                    .expect("in test");
+            }
+        };
+    }
 
-//                 assert_eq!(parsed_query.stream, $parsed_query.stream);
-//                 assert_eq!(parsed_query.media, $parsed_query.media);
-//                 assert_eq!(parsed_query.hashtag, $parsed_query.hashtag);
-//                 assert_eq!(parsed_query.list, $parsed_query.list);
-//                 assert_eq!(user, $user);
-//             }
-//         };
-//     }
+    test_public_endpoint!(public_media {
+        endpoint: "/api/v1/streaming?stream=public:media",
+        user: User {
+            target_timeline: "public:media".to_string(),
+            id: -1,
+            access_token: "no access token".to_string(),
+            langs: None,
+            scopes: OauthScope {
+                all: false,
+                statuses: false,
+                notify: false,
+                lists: false,
+            },
+            logged_in: false,
+            filter: Filter::Language,
+        },
+    });
 
-//     // macro_rules! test_private_endpoint {
-//     //     ($name:ident {
-//     //         endpoint: $path:expr,
-//     //         $(query: $query:expr,)*
-//     //         timeline: $timeline:expr,
-//     //         user: $user:expr,
-//     //     }) => {
-//     //         #[test]
-//     //         fn $name() {
-//     //             let  path = format!("{}?access_token=TEST_USER", $path);
-//     //             $(let path = format!("{}&{}", path, $query);)*
-//     //                 let (timeline, user) = warp::test::request()
-//     //                 .path(&path)
-//     //                 .filter(&filter_incomming_request())
-//     //                 .expect("in test");
-//     //             assert_eq!(&timeline, $timeline);
-//     //             assert_eq!(user, $user);
-//     //             let (timeline, user) = warp::test::request()
-//     //                 .path(&path)
-//     //                 .header("Authorization", "Bearer: TEST_USER")
-//     //                 .filter(&filter_incomming_request())
-//     //                 .expect("in test");
-//     //             assert_eq!(&timeline, $timeline);
-//     //             assert_eq!(user, $user);
-//     //         }
-//     //     };
-//     // }
+    test_public_endpoint!(public_local {
+        endpoint: "/api/v1/streaming?stream=public:local",
+        user: User {
+            target_timeline: "public:local".to_string(),
+            id: -1,
+            access_token: "no access token".to_string(),
+            langs: None,
+            scopes: OauthScope {
+                all: false,
+                statuses: false,
+                notify: false,
+                lists: false,
+            },
+            logged_in: false,
+            filter: Filter::Language,
+        },
+    });
 
-//     //         $(query: $query:expr,)*
-//     //     }) => {
-//     //         #[test]
-//     //         #[should_panic(expected = "Error: Missing access token")]
-//     //         fn $name() {
-//     //             let path = $path;
-//     //             $(let path = format!("{}?{}", path, $query);)*
-//     //             warp::test::request()
-//     //                 .path(&path)
-//     //                 .filter(&filter_incomming_request())
-//     //                 .expect("in test");
-//     //         }
-//     //     };
-//     // }
+    test_public_endpoint!(public_local_media {
+        endpoint: "/api/v1/streaming?stream=public:local:media",
+        user: User {
+            target_timeline: "public:local:media".to_string(),
+            id: -1,
+            access_token: "no access token".to_string(),
+            langs: None,
+            scopes: OauthScope {
+                all: false,
+                statuses: false,
+                notify: false,
+                lists: false,
+            },
+            logged_in: false,
+            filter: Filter::Language,
+        },
+    });
 
-//     #[test]
-//     #[should_panic(expected = "Error: Invalid access token")]
-//     fn bad_auth_token() {
-//         warp::test::request()
-//             .path("/api/v1/streaming?stream=public&access_token=INVALID")
-//             .header("connection", "upgrade")
-//             .header("upgrade", "websocket")
-//             .header("sec-websocket-version", "13")
-//             .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
-//             .filter(&extract_user_and_query())
-//             .expect("to panic");
-//     }
+    test_public_endpoint!(hashtag {
+        endpoint: "/api/v1/streaming?stream=hashtag&tag=a",
+        user: User {
+            target_timeline: "hashtag:a".to_string(),
+            id: -1,
+            access_token: "no access token".to_string(),
+            langs: None,
+            scopes: OauthScope {
+                all: false,
+                statuses: false,
+                notify: false,
+                lists: false,
+            },
+            logged_in: false,
+            filter: Filter::Language,
+        },
+    });
 
-//     test_public_endpoint!(public_media_true {
-//         raw_query: "stream=public&only_media=true",
-//         parsed_query: Query {
-//             stream: "public".to_string(),
-//             media: true,
-//             hashtag: String::new(),
-//             list: 0,
-//         },
-//     });
-//     test_public_endpoint!(public_media_1 {
-//         raw_query: "stream=public&only_media=1",
-//         parsed_query: Query {
-//             stream: "public".to_string(),
-//             media: true,
-//             hashtag: String::new(),
-//             list: 0,
-//         },
-//     });
-//     test_private_endpoint!(user {
-//         raw_query: "stream=user",
-//         parsed_query: Query {
-//             stream: "user".to_string(),
-//             media: false,
-//             hashtag: String::new(),
-//             list: 0,
-//         },
-//         user: TestUser::logged_in(),
-//     });
+    test_public_endpoint!(hashtag_local {
+        endpoint: "/api/v1/streaming?stream=hashtag:local&tag=a",
+        user: User {
+            target_timeline: "hashtag:local:a".to_string(),
+            id: -1,
+            access_token: "no access token".to_string(),
+            langs: None,
+            scopes: OauthScope {
+                all: false,
+                statuses: false,
+                notify: false,
+                lists: false,
+            },
+            logged_in: false,
+            filter: Filter::Language,
+        },
+    });
 
-//     //     test_bad_auth_token_in_query!(public_media_true_bad_auth {
-//     //         endpoint: "/api/v1/streaming/public",
+    test_private_endpoint!(user {
+        endpoint: "/api/v1/streaming?stream=user",
+        user: User {
+            target_timeline: "1".to_string(),
+            id: 1,
+            access_token: "TEST_USER".to_string(),
+            langs: None,
+            scopes: OauthScope {
+                all: true,
+                statuses: false,
+                notify: false,
+                lists: false,
+            },
+            logged_in: true,
+            filter: Filter::NoFilter,
+        },
+    });
 
-//     //         query: "only_media=true",
-//     //     });
-//     //     test_bad_auth_token_in_header!(public_media_1_bad_auth {
-//     //         endpoint: "/api/v1/streaming/public",
-//     //         query: "only_media=1",
-//     //     });
+    test_private_endpoint!(user_notification {
+        endpoint: "/api/v1/streaming?stream=user:notification",
+        user: User {
+            target_timeline: "1".to_string(),
+            id: 1,
+            access_token: "TEST_USER".to_string(),
+            langs: None,
+            scopes: OauthScope {
+                all: true,
+                statuses: false,
+                notify: false,
+                lists: false,
+            },
+            logged_in: true,
+            filter: Filter::Notification,
+        },
+    });
 
-//     //     test_public_endpoint!(public_local {
-//     //         endpoint: "/api/v1/streaming/public/local",
-//     //         timeline: "public:local",
-//     //         user: TestUser::public().set_filter(Language),
-//     //     });
-//     //     test_bad_auth_token_in_query!(public_local_bad_auth_in_query {
-//     //         endpoint: "/api/v1/streaming/public/local",
-//     //     });
-//     //     test_bad_auth_token_in_header!(public_local_bad_auth_in_header {
-//     //         endpoint: "/api/v1/streaming/public/local",
-//     //     });
+    test_private_endpoint!(direct {
+        endpoint: "/api/v1/streaming?stream=direct",
+        user: User {
+            target_timeline: "direct".to_string(),
+            id: 1,
+            access_token: "TEST_USER".to_string(),
+            langs: None,
+            scopes: OauthScope {
+                all: true,
+                statuses: false,
+                notify: false,
+                lists: false,
+            },
+            logged_in: true,
+            filter: Filter::NoFilter,
+        },
+    });
 
-//     //     test_public_endpoint!(public_local_media_true {
-//     //         endpoint: "/api/v1/streaming/public/local?only_media=true",
-//     //         timeline: "public:local:media",
-//     //         user: TestUser::public().set_filter(Language),
-//     //     });
-//     //     test_public_endpoint!(public_local_media_1 {
-//     //         endpoint: "/api/v1/streaming/public/local?only_media=1",
-//     //         timeline: "public:local:media",
-//     //         user: TestUser::public().set_filter(Language),
-//     //     });
-//     //     test_bad_auth_token_in_query!(public_local_media_timeline_bad_auth_in_query {
-//     //         endpoint: "/api/v1/streaming/public/local",
-//     //         query: "only_media=1",
-//     //     });
-//     //     test_bad_auth_token_in_header!(public_local_media_timeline_bad_token_in_header {
-//     //         endpoint: "/api/v1/streaming/public/local",
-//     //         query: "only_media=true",
-//     //     });
+    test_private_endpoint!(list_valid_list {
+        endpoint: "/api/v1/streaming?stream=list&list=1",
+        user: User {
+            target_timeline: "list:1".to_string(),
+            id: 1,
+            access_token: "TEST_USER".to_string(),
+            langs: None,
+            scopes: OauthScope {
+                all: true,
+                statuses: false,
+                notify: false,
+                lists: false,
+            },
+            logged_in: true,
+            filter: Filter::NoFilter,
+        },
+    });
 
-//     //     test_public_endpoint!(hashtag {
-//     //         endpoint: "/api/v1/streaming/hashtag?tag=a",
-//     //         timeline: "hashtag:a",
-//     //         user: TestUser::public(),
-//     //     });
-//     //     test_bad_auth_token_in_query!(hashtag_bad_auth_in_query {
-//     //         endpoint: "/api/v1/streaming/hashtag",
-//     //         query: "tag=a",
-//     //     });
-//     //     test_bad_auth_token_in_header!(hashtag_bad_auth_in_header {
-//     //         endpoint: "/api/v1/streaming/hashtag",
-//     //         query: "tag=a",
-//     //     });
+           test_bad_auth_token_in_query!(public_media_true_bad_auth {
+        endpoint: "/api/v1/streaming?stream=public:media",        
+    });
+    test_bad_auth_token_in_query!(public_local_bad_auth_in_query {
+        endpoint: "/api/v1/streaming?stream=public:local",
+    });
 
-//     //     test_public_endpoint!(hashtag_local {
-//     //         endpoint: "/api/v1/streaming/hashtag/local?tag=a",
-//     //         timeline: "hashtag:a:local",
-//     //         user: TestUser::public(),
-//     //     });
-//     //     test_bad_auth_token_in_query!(hashtag_local_bad_auth_in_query {
-//     //         endpoint: "/api/v1/streaming/hashtag/local",
-//     //         query: "tag=a",
-//     //     });
-//     //     test_bad_auth_token_in_header!(hashtag_local_bad_auth_in_header {
-//     //         endpoint: "/api/v1/streaming/hashtag/local",
-//     //         query: "tag=a",
-//     //     });
+test_bad_auth_token_in_query!(public_local_media_timeline_bad_auth_in_query {
+        endpoint: "/api/v1/streaming?stream=public:local:media",
+        
+    });
+    test_bad_auth_token_in_query!(hashtag_bad_auth_in_query {
+        endpoint: "/api/v1/streaming?stream=hashtag&tag=a",        
+    });
 
-//     //     test_private_endpoint!(user {
-//     //         endpoint: "/api/v1/streaming/user",
-//     //         timeline: "1",
-//     //         user: TestUser::logged_in(),
-//     //     });
-//     //     test_bad_auth_token_in_query!(user_bad_auth_in_query {
-//     //         endpoint: "/api/v1/streaming/user",
-//     //     });
-//     //     test_bad_auth_token_in_header!(user_bad_auth_in_header {
-//     //         endpoint: "/api/v1/streaming/user",
-//     //     });
-//     //     test_missing_auth!(user_missing_auth_token {
-//     //         endpoint: "/api/v1/streaming/user",
-//     //     });
+test_bad_auth_token_in_query!(user_bad_auth_in_query {
+        endpoint: "/api/v1/streaming?stream=user",
+    });
 
-//     //     test_private_endpoint!(user_notification {
-//     //         endpoint: "/api/v1/streaming/user/notification",
-//     //         timeline: "1",
-//     //         user: TestUser::logged_in().set_filter(Notification),
-//     //     });
-//     //     test_bad_auth_token_in_query!(user_notification_bad_auth_in_query {
-//     //         endpoint: "/api/v1/streaming/user/notification",
-//     //     });
-//     //     test_bad_auth_token_in_header!(user_notification_bad_auth_in_header {
-//     //         endpoint: "/api/v1/streaming/user/notification",
-//     //     });
-//     //     test_missing_auth!(user_notification_missing_auth_token {
-//     //         endpoint: "/api/v1/streaming/user/notification",
-//     //     });
+test_missing_auth!(user_missing_auth_token {
+        endpoint: "/api/v1/streaming?stream=user",
+    });
 
-//     //     test_private_endpoint!(direct {
-//     //         endpoint: "/api/v1/streaming/direct",
-//     //         timeline: "direct:1",
-//     //         user: TestUser::logged_in(),
-//     //     });
-//     //     test_bad_auth_token_in_query!(direct_bad_auth_in_query {
-//     //         endpoint: "/api/v1/streaming/direct",
-//     //     });
-//     //     test_bad_auth_token_in_header!(direct_bad_auth_in_header {
-//     //         endpoint: "/api/v1/streaming/direct",
-//     //     });
-//     //     test_missing_auth!(direct_missing_auth_token {
-//     //         endpoint: "/api/v1/streaming/direct",
-//     //     });
+test_bad_auth_token_in_query!(user_notification_bad_auth_in_query {
+        endpoint: "/api/v1/streaming?stream=user:notification",
+    });
 
-//     //     test_private_endpoint!(list_valid_list {
-//     //         endpoint: "/api/v1/streaming/list",
-//     //         query: "list=1",
-//     //         timeline: "list:1",
-//     //         user: TestUser::logged_in(),
-//     //     });
-//     //     test_bad_auth_token_in_query!(list_bad_auth_in_query {
-//     //         endpoint: "/api/v1/streaming/list",
-//     //         query: "list=1",
-//     //     });
-//     //     test_bad_auth_token_in_header!(list_bad_auth_in_header {
-//     //         endpoint: "/api/v1/streaming/list",
-//     //         query: "list=1",
-//     //     });
-//     //     test_missing_auth!(list_missing_auth_token {
-//     //         endpoint: "/api/v1/streaming/list",
-//     //         query: "list=1",
-//     //     });
+test_missing_auth!(user_notification_missing_auth_token {
+        endpoint: "/api/v1/streaming?stream=user:notification",
+    });
 
-// }
+test_bad_auth_token_in_query!(direct_bad_auth_in_query {
+        endpoint: "/api/v1/streaming?stream=direct",
+    });
+
+test_missing_auth!(direct_missing_auth_token {
+        endpoint: "/api/v1/streaming?stream=direct",
+    });
+
+test_bad_auth_token_in_query!(list_bad_auth_in_query {
+        endpoint: "/api/v1/streaming?stream=list&list=1",        
+    });
+
+test_missing_auth!(list_missing_auth_token {
+        endpoint: "/api/v1/streaming?stream=list&list=1",        
+    });
+}

--- a/src/parse_client_request/ws.rs
+++ b/src/parse_client_request/ws.rs
@@ -5,6 +5,7 @@ use warp::{filters::BoxedFilter, path, Filter};
 /// WebSocket filters
 fn parse_query() -> BoxedFilter<(Query,)> {
     path!("api" / "v1" / "streaming")
+        .and(path::end())
         .and(warp::query())
         .and(query::Auth::to_filter())
         .and(query::Media::to_filter())
@@ -60,7 +61,6 @@ mod test {
             }
         };
     }
-
     macro_rules! test_private_endpoint {
         ($name:ident {
             endpoint: $path:expr,
@@ -81,7 +81,6 @@ mod test {
             }
         };
     }
-
     macro_rules! test_bad_auth_token_in_query {
         ($name: ident {
             endpoint: $path:expr,
@@ -99,7 +98,6 @@ mod test {
             }
         };
     }
-
     macro_rules! test_missing_auth {
         ($name: ident {
             endpoint: $path:expr,            
@@ -115,7 +113,7 @@ mod test {
             }
         };
     }
-
+    
     test_public_endpoint!(public_media {
         endpoint: "/api/v1/streaming?stream=public:media",
         user: User {
@@ -133,7 +131,6 @@ mod test {
             filter: Filter::Language,
         },
     });
-
     test_public_endpoint!(public_local {
         endpoint: "/api/v1/streaming?stream=public:local",
         user: User {
@@ -151,7 +148,6 @@ mod test {
             filter: Filter::Language,
         },
     });
-
     test_public_endpoint!(public_local_media {
         endpoint: "/api/v1/streaming?stream=public:local:media",
         user: User {
@@ -169,7 +165,6 @@ mod test {
             filter: Filter::Language,
         },
     });
-
     test_public_endpoint!(hashtag {
         endpoint: "/api/v1/streaming?stream=hashtag&tag=a",
         user: User {
@@ -187,7 +182,6 @@ mod test {
             filter: Filter::Language,
         },
     });
-
     test_public_endpoint!(hashtag_local {
         endpoint: "/api/v1/streaming?stream=hashtag:local&tag=a",
         user: User {
@@ -205,7 +199,7 @@ mod test {
             filter: Filter::Language,
         },
     });
-
+    
     test_private_endpoint!(user {
         endpoint: "/api/v1/streaming?stream=user",
         user: User {
@@ -223,7 +217,6 @@ mod test {
             filter: Filter::NoFilter,
         },
     });
-
     test_private_endpoint!(user_notification {
         endpoint: "/api/v1/streaming?stream=user:notification",
         user: User {
@@ -241,7 +234,6 @@ mod test {
             filter: Filter::Notification,
         },
     });
-
     test_private_endpoint!(direct {
         endpoint: "/api/v1/streaming?stream=direct",
         user: User {
@@ -259,7 +251,6 @@ mod test {
             filter: Filter::NoFilter,
         },
     });
-
     test_private_endpoint!(list_valid_list {
         endpoint: "/api/v1/streaming?stream=list&list=1",
         user: User {
@@ -277,51 +268,55 @@ mod test {
             filter: Filter::NoFilter,
         },
     });
-
-           test_bad_auth_token_in_query!(public_media_true_bad_auth {
+    
+    test_bad_auth_token_in_query!(public_media_true_bad_auth {
         endpoint: "/api/v1/streaming?stream=public:media",        
     });
     test_bad_auth_token_in_query!(public_local_bad_auth_in_query {
         endpoint: "/api/v1/streaming?stream=public:local",
     });
-
-test_bad_auth_token_in_query!(public_local_media_timeline_bad_auth_in_query {
+    test_bad_auth_token_in_query!(public_local_media_timeline_bad_auth_in_query {
         endpoint: "/api/v1/streaming?stream=public:local:media",
         
     });
     test_bad_auth_token_in_query!(hashtag_bad_auth_in_query {
         endpoint: "/api/v1/streaming?stream=hashtag&tag=a",        
     });
-
-test_bad_auth_token_in_query!(user_bad_auth_in_query {
+    test_bad_auth_token_in_query!(user_bad_auth_in_query {
         endpoint: "/api/v1/streaming?stream=user",
     });
-
-test_missing_auth!(user_missing_auth_token {
+    test_missing_auth!(user_missing_auth_token {
         endpoint: "/api/v1/streaming?stream=user",
     });
-
-test_bad_auth_token_in_query!(user_notification_bad_auth_in_query {
+    test_bad_auth_token_in_query!(user_notification_bad_auth_in_query {
         endpoint: "/api/v1/streaming?stream=user:notification",
     });
-
-test_missing_auth!(user_notification_missing_auth_token {
+    test_missing_auth!(user_notification_missing_auth_token {
         endpoint: "/api/v1/streaming?stream=user:notification",
     });
-
-test_bad_auth_token_in_query!(direct_bad_auth_in_query {
+    test_bad_auth_token_in_query!(direct_bad_auth_in_query {
         endpoint: "/api/v1/streaming?stream=direct",
     });
-
-test_missing_auth!(direct_missing_auth_token {
+    test_missing_auth!(direct_missing_auth_token {
         endpoint: "/api/v1/streaming?stream=direct",
     });
-
-test_bad_auth_token_in_query!(list_bad_auth_in_query {
+    test_bad_auth_token_in_query!(list_bad_auth_in_query {
+        endpoint: "/api/v1/streaming?stream=list&list=1",        
+    });
+    test_missing_auth!(list_missing_auth_token {
         endpoint: "/api/v1/streaming?stream=list&list=1",        
     });
 
-test_missing_auth!(list_missing_auth_token {
-        endpoint: "/api/v1/streaming?stream=list&list=1",        
-    });
+    #[test]
+    #[should_panic(expected = "NotFound")]
+    fn nonexistant_endpoint() {
+        warp::test::request()
+            .path("/api/v1/streaming/DOES_NOT_EXIST")
+            .header("connection", "upgrade")
+            .header("upgrade", "websocket")
+            .header("sec-websocket-version", "13")
+            .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+            .filter(&extract_user_or_reject())
+            .expect("in test");
+    }
 }

--- a/src/redis_to_client_stream/client_agent.rs
+++ b/src/redis_to_client_stream/client_agent.rs
@@ -40,7 +40,7 @@ impl ClientAgent {
             receiver: sync::Arc::new(sync::Mutex::new(Receiver::new())),
             id: Uuid::default(),
             target_timeline: String::new(),
-            current_user: User::public(),
+            current_user: User::default(),
         }
     }
 

--- a/src/redis_to_client_stream/client_agent.rs
+++ b/src/redis_to_client_stream/client_agent.rs
@@ -61,12 +61,12 @@ impl ClientAgent {
     /// a different user, the `Receiver` is responsible for figuring
     /// that out and avoiding duplicated connections.  Thus, it is safe to
     /// use this method for each new client connection.
-    pub fn init_for_user(&mut self, target_timeline: &str, user: User) {
+    pub fn init_for_user(&mut self, user: User) {
         self.id = Uuid::new_v4();
-        self.target_timeline = target_timeline.to_owned();
+        self.target_timeline = user.target_timeline.to_owned();
         self.current_user = user;
         let mut receiver = self.receiver.lock().expect("No thread panic (stream.rs)");
-        receiver.manage_new_timeline(self.id, target_timeline);
+        receiver.manage_new_timeline(self.id, &self.target_timeline);
     }
 }
 


### PR DESCRIPTION
This PR adds tests for the websocket routes.  In combination with #37, this closes #27—all tests have now been replaced with unit tests.  Specifically, every flodgatt contains 54 tests that test every possible route, both SSE and WS.  These tests ensure that each request is either rejected (if not authorized) or is correctly parsed into a `User` that is passed on to `ClientAgent`.

We do not yet have tests for the functionality in the `ClientAgent` or `Receiver`—that is, we aren't testing what we do with the `User` once it is generated.  But that is the obvious next step in increasing testing coverage.  