### PR TITLE
Temporarily remove Postgres SSL support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,7 +308,6 @@ dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.16.0-rc.2 (git+https://github.com/sfackler/rust-postgres.git)",
  "postgres-openssl 0.2.0-rc.1 (git+https://github.com/sfackler/rust-postgres.git)",
  "pretty_env_logger 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ postgres = { git = "https://github.com/sfackler/rust-postgres.git" }
 uuid = { version = "0.7", features = ["v4"] }
 dotenv = "0.14.0"
 lazy_static = "1.3.0"
-openssl = "0.10.24"
 postgres-openssl = { git = "https://github.com/sfackler/rust-postgres.git"}
 
 [features]

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,7 +40,7 @@ fn default(var: &str, default_var: &str) -> String {
 }
 
 lazy_static! {
-    static ref POSTGRES_ADDR: String = match &env::var("POSTGRESS_ADDR") {
+    static ref POSTGRES_ADDR: String = match &env::var("POSTGRES_ADDR") {
         Ok(url) => {
             warn!("DATABASE_URL env variable set.  Trying to connect to Postgres with that URL instead of any values set in DB_HOST, DB_USER, DB_NAME, DB_PASS, or DB_PORT.");
             url.to_string()
@@ -113,12 +113,13 @@ pub fn logging_and_env() {
 
 /// Configure Postgres and return a connection
 pub fn postgres() -> postgres::Client {
-    use openssl::ssl::{SslConnector, SslMethod};
-    use postgres_openssl::MakeTlsConnector;
-    let mut builder = SslConnector::builder(SslMethod::tls()).unwrap();
-    builder.set_ca_file("/etc/ssl/cert.pem").unwrap();
-    let connector = MakeTlsConnector::new(builder.build());
-    postgres::Client::connect(&POSTGRES_ADDR.to_string(), connector)
+    // use openssl::ssl::{SslConnector, SslMethod};
+    // use postgres_openssl::MakeTlsConnector;
+    // let mut builder = SslConnector::builder(SslMethod::tls()).unwrap();
+    // builder.set_ca_file("/etc/ssl/cert.pem").unwrap();
+    // let connector = MakeTlsConnector::new(builder.build());
+    // TODO: add TLS support, remove `NoTls`
+    postgres::Client::connect(&POSTGRES_ADDR.to_string(), postgres::NoTls)
         .expect("Can connect to local Postgres")
 }
 


### PR DESCRIPTION
Remove Postgres SSL support, which was not working at the moment and
was preventing flogatt from running on servers without openssl.

We should re-enable SSL support at a later time.