### PR TITLE
Fix CPU issue caused by blocking code

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -130,6 +130,9 @@ pub fn redis_addr() -> (net::TcpStream, net::TcpStream) {
     pubsub_connection
         .set_read_timeout(Some(time::Duration::from_millis(10)))
         .expect("Can set read timeout for Redis connection");
+    pubsub_connection
+        .set_nonblocking(true)
+        .expect("set_nonblocking call failed");
     let secondary_redis_connection =
         net::TcpStream::connect(&REDIS_ADDR.to_string()).expect("Can connect to Redis");
     secondary_redis_connection

--- a/src/redis_to_client_stream/client_agent.rs
+++ b/src/redis_to_client_stream/client_agent.rs
@@ -83,6 +83,7 @@ impl futures::stream::Stream for ClientAgent {
     /// replies with `Ok(NotReady)`.  The `ClientAgent` bubles up any
     /// errors from the underlying data structures.
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        let start_time = std::time::Instant::now();
         let result = {
             let mut receiver = self
                 .receiver
@@ -90,6 +91,9 @@ impl futures::stream::Stream for ClientAgent {
                 .expect("ClientAgent: No other thread panic");
             receiver.configure_for_polling(self.id, &self.target_timeline.clone());
             receiver.poll()
+        };
+        if start_time.elapsed().as_millis() > 1 {
+            log::warn!("Polling the Receiver took: {:?}", start_time.elapsed());
         };
 
         match result {

--- a/src/redis_to_client_stream/client_agent.rs
+++ b/src/redis_to_client_stream/client_agent.rs
@@ -18,9 +18,8 @@
 use super::receiver::Receiver;
 use crate::parse_client_request::user::User;
 use futures::{Async, Poll};
-use log;
 use serde_json::{json, Value};
-use std::{sync, time};
+use std::sync;
 use tokio::io::Error;
 use uuid::Uuid;
 
@@ -84,21 +83,13 @@ impl futures::stream::Stream for ClientAgent {
     /// replies with `Ok(NotReady)`.  The `ClientAgent` bubles up any
     /// errors from the underlying data structures.
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        let start_time = time::Instant::now();
         let result = {
-            let before_locking_receiver = time::Instant::now();
             let mut receiver = self
                 .receiver
                 .lock()
                 .expect("ClientAgent: No other thread panic");
-            let before_configuring_receiver = time::Instant::now();
             receiver.configure_for_polling(self.id, &self.target_timeline.clone());
-            let before_polling_receiver = time::Instant::now();
-            let result = receiver.poll();
-            if start_time.elapsed() > time::Duration::from_millis(20) {
-                log::warn!("Polling TOTAL time: {:?}\n since poll function: {:?}\n since configuring: {:?}\n since locking: {:?}", start_time.elapsed(), before_polling_receiver.elapsed(), before_configuring_receiver.elapsed(), before_locking_receiver.elapsed());
-            }
-            result
+            receiver.poll()
         };
 
         match result {

--- a/src/redis_to_client_stream/receiver.rs
+++ b/src/redis_to_client_stream/receiver.rs
@@ -67,6 +67,7 @@ impl Receiver {
     /// that there's a subscription to the current one.  If there isn't, then
     /// subscribe to it.
     fn subscribe_or_unsubscribe_as_needed(&mut self, timeline: &str) {
+        let start_time = std::time::Instant::now();
         let mut timelines_to_modify = Vec::new();
         struct Change {
             timeline: String,
@@ -111,6 +112,9 @@ impl Receiver {
                 pubsub_cmd!("subscribe", self, change.timeline.clone());
             }
         }
+        if start_time.elapsed().as_millis() > 1 {
+            log::warn!("Sending cmd to Redis took: {:?}", start_time.elapsed());
+        };
     }
 
     fn get_target_msg_queue(&mut self) -> collections::hash_map::Entry<Uuid, MsgQueue> {


### PR DESCRIPTION
This PR fixes a major issue that contributed to the CPU slowdown—a method that purported to be asynchronous was calling a synchronous function internally.  This synchronous function took ~15ms to run (per request), which was fast enough to not be noticeable without detailed logging but slow enough to cause significant issues under load.

Once I identified the issue, the fix was fairly simple and results in the polls of the Redis stream appropriately taking only ~10µs.  In combination with #52, I am hopeful that this change will be enough to address the anomalously high CPU usage we saw during early testing.  Based on these two PRs, I'm closing #32, though we can re-open it if CPU usage is a problem in later testing.      