### PR TITLE
Redis hostname

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flodgatt"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flodgatt"
 description = "A blazingly fast drop-in replacement for the Mastodon streaming api server"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Daniel Long Sockwell <daniel@codesections.com", "Julian Laubstein <contact@julianlaubstein.de>"]
 edition = "2018"
 

--- a/src/config/redis_cfg_types.rs
+++ b/src/config/redis_cfg_types.rs
@@ -1,20 +1,14 @@
 use crate::from_env_var;
-use std::{
-    net::{IpAddr, Ipv4Addr},
-    time::Duration,
-};
+use std::time::Duration;
 //use std::{fmt, net::IpAddr, os::unix::net::UnixListener, str::FromStr, time::Duration};
 //use strum_macros::{EnumString, EnumVariantNames};
 
 from_env_var!(
     /// The host address where Redis is running
     let name = RedisHost;
-    let default: IpAddr = IpAddr::V4("127.0.0.1".parse().expect("hardcoded"));
-    let (env_var, allowed_values) = ("REDIS_HOST", "a valid address (e.g., 127.0.0.1)".to_string());
-    let from_str = |s| match s {
-        "localhost" => Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
-        _ => s.parse().ok(),
-    };
+    let default: String = "127.0.0.1".to_string(); 
+    let (env_var, allowed_values) = ("REDIS_HOST", "any string".to_string());
+    let from_str = |s| Some(s.to_string());
 );
 from_env_var!(
     /// The port Redis is running on

--- a/src/redis_to_client_stream/redis/redis_connection.rs
+++ b/src/redis_to_client_stream/redis/redis_connection.rs
@@ -56,7 +56,7 @@ fn send_test_ping(mut conn: net::TcpStream) -> net::TcpStream {
 
 impl RedisConn {
     pub fn new(redis_cfg: RedisConfig) -> Self {
-        let addr = net::SocketAddr::from((*redis_cfg.host, *redis_cfg.port));
+        let addr = format!("{}:{}", *redis_cfg.host, *redis_cfg.port);
         let conn_err = |e| {
             err::die_with_msg(format!(
                 "Could not connect to Redis at {}:{}.\n             Error detail: {}",
@@ -76,7 +76,7 @@ impl RedisConn {
             conn
         };
         let (primary_conn, secondary_conn) = (
-            update_conn(net::TcpStream::connect(addr).unwrap_or_else(conn_err)),
+            update_conn(net::TcpStream::connect(addr.clone()).unwrap_or_else(conn_err)),
             update_conn(net::TcpStream::connect(addr).unwrap_or_else(conn_err)),
         );
         primary_conn


### PR DESCRIPTION
This PR allows the user to supply any string as the `REDIS_HOST` env variable.  The string will be parsed as an IP address or a hostname; if it cannot be parsed as either, Flodgatt will return an error.