### PR TITLE
Treat env vars set to "" as if they were unset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flodgatt"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flodgatt"
 description = "A blazingly fast drop-in replacement for the Mastodon streaming api server"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["Daniel Long Sockwell <daniel@codesections.com", "Julian Laubstein <contact@julianlaubstein.de>"]
 edition = "2018"
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -117,13 +117,21 @@ macro_rules! from_env_var {
                 $body
             }
             pub fn maybe_update(self, var: Option<&String>) -> Self {
-                if let Some(value) = var {
-                    Self(Self::inner_from_str(value).unwrap_or_else(|| {
+                match var {
+                    Some(empty_string) if empty_string.is_empty() => Self::default(),
+                    Some(value) => Self(Self::inner_from_str(value).unwrap_or_else(|| {
                         crate::err::env_var_fatal($env_var, value, $allowed_values)
-                    }))
-                } else {
-                    self
+                    })),
+                    None => self,
                 }
+
+                // if let Some(value) = var {
+                //     Self(Self::inner_from_str(value).unwrap_or_else(|| {
+                //         crate::err::env_var_fatal($env_var, value, $allowed_values)
+                //     }))
+                // } else {
+                //     self
+                // }
             }
         }
     };


### PR DESCRIPTION
This PR causes Flodgatt to treat environmental variables set to the empty string (`""`) as though they were unset—meaning that Flodgatt will use the default value for that variable rather than using the empty string.

This change means that it is no longer possible to set environmental variables to the empty string, which is why this behavior was not in the prior version of Flodgatt.  However, many shells do not make it easy to unset environmental variables and users frequently "unset" them by setting them to the empty string.  Thus, it seems better to treat empty environmental variables as though they were unset.  https://unix.stackexchange.com/questions/27708/is-there-a-difference-between-setting-an-environment-variable-to-the-empty-strin