### PR TITLE
Send empty message as a keepalive ping

### DIFF
--- a/src/redis_to_client_stream/mod.rs
+++ b/src/redis_to_client_stream/mod.rs
@@ -76,7 +76,7 @@ pub fn send_updates_to_ws(
                 tx.unbounded_send(msg).expect("No send error");
             };
             if time.elapsed() > time::Duration::from_secs(30) {
-                let msg = warp::ws::Message::ping(Vec::new());
+                let msg = warp::ws::Message::text("{}");
                 tx.unbounded_send(msg).expect("Can ping");
                 time = time::Instant::now();
             }


### PR DESCRIPTION
This PR provides a workaround for the timeout issue created by ping frames not being sent correctly.

Specifically, the ping sent by `warp::filters::ws::ping()` is not registering as a valid message for the purpose of keeping the connection alive.  Thus, connections are timing out after 60 seconds, and need to be reestablished.  This appears to be a bug with the way Warp sends pings and I'll open an issue.  However, even if fixed upstream, it will be non-trivial to incorporate the fix because the latest version of Warp has breaking changes (see #75).

As a workaround, this PR sends a message consisting of minimally valid JSON (`{}`) which serves as a keep-alive ping. 