### PR TITLE
Update logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flodgatt"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flodgatt"
 description = "A blazingly fast drop-in replacement for the Mastodon streaming api server"
-version = "0.4.6"
+version = "0.4.7"
 authors = ["Daniel Long Sockwell <daniel@codesections.com", "Julian Laubstein <contact@julianlaubstein.de>"]
 edition = "2018"
 


### PR DESCRIPTION
This PR makes two minor changes to the error logging.

First, it logs each incoming connection at the `info` level rather than the `warn` level.  This should make the `warn` log significantly less cluttered in production/tests on larger servers.

Second, it prevents an incorrect error from being logged when Flodgatt is connected via a Unix socket. When using a socket, a closed connection registers as a broken pipe error; but this is not an error—it is a connection being correctly closed.  With this change, these errors will no longer be displayed and, instead, an `info` message will correctly reflect that the connection was closed. 