### PR TITLE
Increase verbosity of debug info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flodgatt"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flodgatt"
 description = "A blazingly fast drop-in replacement for the Mastodon streaming api server"
-version = "0.4.7"
+version = "0.4.8"
 authors = ["Daniel Long Sockwell <daniel@codesections.com", "Julian Laubstein <contact@julianlaubstein.de>"]
 edition = "2018"
 

--- a/src/parse_client_request/sse.rs
+++ b/src/parse_client_request/sse.rs
@@ -179,6 +179,7 @@ mod test {
         user: User {
             target_timeline: "public:media".to_string(),
             id: -1,
+            email: "".to_string(),
             access_token: "no access token".to_string(),
             langs: None,
             scopes: OauthScope {
@@ -196,6 +197,7 @@ mod test {
         user: User {
             target_timeline: "public:media".to_string(),
             id: -1,
+            email: "".to_string(),
             access_token: "no access token".to_string(),
             langs: None,
             scopes: OauthScope {
@@ -213,6 +215,7 @@ mod test {
         user: User {
             target_timeline: "public:local".to_string(),
             id: -1,
+            email: "".to_string(),
             access_token: "no access token".to_string(),
             langs: None,
             scopes: OauthScope {
@@ -230,6 +233,7 @@ mod test {
         user: User {
             target_timeline: "public:local:media".to_string(),
             id: -1,
+            email: "".to_string(),
             access_token: "no access token".to_string(),
             langs: None,
             scopes: OauthScope {
@@ -247,6 +251,7 @@ mod test {
         user: User {
             target_timeline: "public:local:media".to_string(),
             id: -1,
+            email: "".to_string(),
             access_token: "no access token".to_string(),
             langs: None,
             scopes: OauthScope {
@@ -264,6 +269,7 @@ mod test {
         user: User {
             target_timeline: "hashtag:a".to_string(),
             id: -1,
+            email: "".to_string(),
             access_token: "no access token".to_string(),
             langs: None,
             scopes: OauthScope {
@@ -281,6 +287,7 @@ mod test {
         user: User {
             target_timeline: "hashtag:local:a".to_string(),
             id: -1,
+            email: "".to_string(),
             access_token: "no access token".to_string(),
             langs: None,
             scopes: OauthScope {
@@ -299,6 +306,7 @@ mod test {
         user: User {
             target_timeline: "1".to_string(),
             id: 1,
+            email: "user@example.com".to_string(),
             access_token: "TEST_USER".to_string(),
             langs: None,
             scopes: OauthScope {
@@ -316,6 +324,7 @@ mod test {
         user: User {
             target_timeline: "1".to_string(),
             id: 1,
+            email: "user@example.com".to_string(),
             access_token: "TEST_USER".to_string(),
             langs: None,
             scopes: OauthScope {
@@ -333,6 +342,7 @@ mod test {
         user: User {
             target_timeline: "direct".to_string(),
             id: 1,
+            email: "user@example.com".to_string(),
             access_token: "TEST_USER".to_string(),
             langs: None,
             scopes: OauthScope {
@@ -352,6 +362,7 @@ mod test {
         user: User {
             target_timeline: "list:1".to_string(),
             id: 1,
+            email: "user@example.com".to_string(),
             access_token: "TEST_USER".to_string(),
             langs: None,
             scopes: OauthScope {

--- a/src/parse_client_request/user/mock_postgres.rs
+++ b/src/parse_client_request/user/mock_postgres.rs
@@ -11,10 +11,11 @@ impl PostgresPool {
 pub fn query_for_user_data(
     access_token: &str,
     _pg_pool: PostgresPool,
-) -> (i64, Option<Vec<String>>, Vec<String>) {
-    let (user_id, lang, scopes) = if access_token == "TEST_USER" {
+) -> (i64, String, Option<Vec<String>>, Vec<String>) {
+    let (user_id, email, lang, scopes) = if access_token == "TEST_USER" {
         (
             1,
+            "user@example.com".to_string(),
             None,
             vec![
                 "read".to_string(),
@@ -23,9 +24,9 @@ pub fn query_for_user_data(
             ],
         )
     } else {
-        (-1, None, Vec::new())
+        (-1, "".to_string(), None, Vec::new())
     };
-    (user_id, lang, scopes)
+    (user_id, email, lang, scopes)
 }
 
 pub fn query_list_owner(list_id: i64, _pg_pool: PostgresPool) -> Option<i64> {

--- a/src/parse_client_request/user/mod.rs
+++ b/src/parse_client_request/user/mod.rs
@@ -26,7 +26,7 @@ impl Default for Filter {
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct User {
     pub target_timeline: String,
-    pub email: String,
+    pub email: String, // We only use email for logging; we could cut it for performance
     pub id: i64,
     pub access_token: String,
     pub scopes: OauthScope,
@@ -64,7 +64,7 @@ impl User {
             None => (
                 -1,
                 "no access token".to_owned(),
-                "no email".to_owned(),
+                "".to_string(),
                 OauthScope::default(),
                 None,
                 false,

--- a/src/parse_client_request/user/postgres.rs
+++ b/src/parse_client_request/user/postgres.rs
@@ -28,13 +28,13 @@ impl PostgresPool {
 pub fn query_for_user_data(
     access_token: &str,
     pg_pool: PostgresPool,
-) -> (i64, Option<Vec<String>>, Vec<String>) {
+) -> (i64, String, Option<Vec<String>>, Vec<String>) {
     let mut conn = pg_pool.0.get().unwrap();
 
     let query_result = conn
             .query(
                 "
-SELECT oauth_access_tokens.resource_owner_id, users.account_id, users.chosen_languages, oauth_access_tokens.scopes
+SELECT oauth_access_tokens.resource_owner_id, users.account_id, users.email, users.chosen_languages, oauth_access_tokens.scopes
 FROM
 oauth_access_tokens
 INNER JOIN users ON
@@ -48,15 +48,16 @@ LIMIT 1",
     if !query_result.is_empty() {
         let only_row: &postgres::Row = query_result.get(0).unwrap();
         let id: i64 = only_row.get(1);
+        let email: String = only_row.get(2);
         let scopes = only_row
-            .get::<_, String>(3)
+            .get::<_, String>(4)
             .split(' ')
             .map(|s| s.to_owned())
             .collect();
-        let langs: Option<Vec<String>> = only_row.get(2);
-        (id, langs, scopes)
+        let langs: Option<Vec<String>> = only_row.get(3);
+        (id, email, langs, scopes)
     } else {
-        (-1, None, Vec::new())
+        (-1, "".to_string(), None, Vec::new())
     }
 }
 

--- a/src/parse_client_request/ws.rs
+++ b/src/parse_client_request/ws.rs
@@ -126,6 +126,7 @@ mod test {
         user: User {
             target_timeline: "public:media".to_string(),
             id: -1,
+            email: "".to_string(),
             access_token: "no access token".to_string(),
             langs: None,
             scopes: OauthScope {
@@ -143,6 +144,7 @@ mod test {
         user: User {
             target_timeline: "public:local".to_string(),
             id: -1,
+            email: "".to_string(),
             access_token: "no access token".to_string(),
             langs: None,
             scopes: OauthScope {
@@ -160,6 +162,7 @@ mod test {
         user: User {
             target_timeline: "public:local:media".to_string(),
             id: -1,
+            email: "".to_string(),
             access_token: "no access token".to_string(),
             langs: None,
             scopes: OauthScope {
@@ -177,6 +180,7 @@ mod test {
         user: User {
             target_timeline: "hashtag:a".to_string(),
             id: -1,
+            email: "".to_string(),
             access_token: "no access token".to_string(),
             langs: None,
             scopes: OauthScope {
@@ -194,6 +198,7 @@ mod test {
         user: User {
             target_timeline: "hashtag:local:a".to_string(),
             id: -1,
+            email: "".to_string(),
             access_token: "no access token".to_string(),
             langs: None,
             scopes: OauthScope {
@@ -212,6 +217,7 @@ mod test {
         user: User {
             target_timeline: "1".to_string(),
             id: 1,
+            email: "user@example.com".to_string(),
             access_token: "TEST_USER".to_string(),
             langs: None,
             scopes: OauthScope {
@@ -229,6 +235,7 @@ mod test {
         user: User {
             target_timeline: "1".to_string(),
             id: 1,
+            email: "user@example.com".to_string(),
             access_token: "TEST_USER".to_string(),
             langs: None,
             scopes: OauthScope {
@@ -246,6 +253,7 @@ mod test {
         user: User {
             target_timeline: "direct".to_string(),
             id: 1,
+            email: "user@example.com".to_string(),
             access_token: "TEST_USER".to_string(),
             langs: None,
             scopes: OauthScope {
@@ -263,6 +271,7 @@ mod test {
         user: User {
             target_timeline: "list:1".to_string(),
             id: 1,
+            email: "user@example.com".to_string(),
             access_token: "TEST_USER".to_string(),
             langs: None,
             scopes: OauthScope {

--- a/src/redis_to_client_stream/client_agent.rs
+++ b/src/redis_to_client_stream/client_agent.rs
@@ -28,8 +28,8 @@ use uuid::Uuid;
 pub struct ClientAgent {
     receiver: sync::Arc<sync::Mutex<Receiver>>,
     id: uuid::Uuid,
-    target_timeline: String,
-    current_user: User,
+    pub target_timeline: String,
+    pub current_user: User,
 }
 
 impl ClientAgent {
@@ -111,7 +111,7 @@ impl futures::stream::Stream for ClientAgent {
 /// The message to send to the client (which might not literally be a toot in some cases).
 struct Toot {
     category: String,
-    payload: String,
+    payload: Value,
     language: Option<String>,
 }
 
@@ -127,7 +127,7 @@ impl Toot {
 
         Self {
             category,
-            payload: value["payload"].to_string(),
+            payload: value["payload"].clone(),
             language,
         }
     }


### PR DESCRIPTION
This PR adds significantly more debug information at the `RUST_LOG=warn` level.  (Semantically, the info added here is more appropriate at the `RUST_LOG=info` level – it provides info about normal functioning, not a warning of something unusual.  But `info` logging contains a lot of other messages and I don't want these to get lost.  Once we've debugged the current issues, I plan to downgrade these to `info`).

Specifically, this adds one type of logging and makes another more verbose:
1. Flodgatt now logs an event every time it sends an update to a user; the log notes the content of the toot, the timeline it came from, and the recipient's email & user id.  Hopefully, this will allow us to debug the issue of certain messages not appearing on the local timeline in Firefox containers.
2. Flodgatt provides timeline/user information when logging errors that occur in sending messages.  Hopefully this will allow us to determine whether the `WARN  flodgatt::redis_to_client_stream > WebSocket protocol error: Connection reset without closing handshake` errors are cause by clients disconnecting without closing the connection or are due to a bug in our connection code.  If the latter, then it is not an error at all – we *should* be closing the connection when clients disconnect, and the solution is simply to not log the error.  If that's _not_ the case, then we have some other work to do.

Two notes on this PR.  First, this level of logging will clearly be excessive when run in production (it logs an event every time _any_ user gets an update).  This level of logging is likely high enough printing it to the console could be a significant bottleneck.  Accordingly,  I don't recommend running for long with this level of logging – just for long enough to get initial results and, hopefully, enough info to resolve the current bugs.

Second: This PR to be able to log the email address associated with a particular message, this PR adds code to query Postgres for their email – we don't need the user email for anything else.  This _may_ add unjustified overhead (though it is fairly minimal; we query Postgres only once per connection).  If we are looking for performance improvements in the future, we can remove this logging and switch to logging only the less-descriptive numerical user id.