### PR TITLE
Filter toots based on user and domain blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flodgatt"
 description = "A blazingly fast drop-in replacement for the Mastodon streaming api server"
-version = "0.4.8"
+version = "0.5.0"
 authors = ["Daniel Long Sockwell <daniel@codesections.com", "Julian Laubstein <contact@julianlaubstein.de>"]
 edition = "2018"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
 
     let client_agent_sse = ClientAgent::blank(redis_cfg);
     let client_agent_ws = client_agent_sse.clone_with_shared_receiver();
-    let pg_pool = user::PostgresPool::new(postgres_cfg);
+    let pg_pool = user::PgPool::new(postgres_cfg);
 
     log::warn!("Streaming server initialized and ready to accept connections");
 

--- a/src/parse_client_request/sse.rs
+++ b/src/parse_client_request/sse.rs
@@ -74,7 +74,7 @@ pub fn extract_user_or_reject(pg_pool: PgPool) -> BoxedFilter<(User,)> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::parse_client_request::user::{Filter, OauthScope, PostgresPool};
+    use crate::parse_client_request::user::{Blocks, Filter, OauthScope, PgPool};
 
     macro_rules! test_public_endpoint {
         ($name:ident {
@@ -83,7 +83,7 @@ mod test {
         }) => {
             #[test]
             fn $name() {
-                let mock_pg_pool = PostgresPool::new();
+                let mock_pg_pool = PgPool::new();
                 let user = warp::test::request()
                     .path($path)
                     .filter(&extract_user_or_reject(mock_pg_pool))
@@ -101,7 +101,7 @@ mod test {
             #[test]
             fn $name() {
                 let  path = format!("{}?access_token=TEST_USER", $path);
-                let mock_pg_pool = PostgresPool::new();
+                let mock_pg_pool = PgPool::new();
                 $(let path = format!("{}&{}", path, $query);)*
                     let  user = warp::test::request()
                     .path(&path)
@@ -127,7 +127,7 @@ mod test {
             fn $name() {
                 let  path = format!("{}?access_token=INVALID", $path);
                 $(let path = format!("{}&{}", path, $query);)*
-                let mock_pg_pool = PostgresPool::new();
+                let mock_pg_pool = PgPool::new();
                 warp::test::request()
                     .path(&path)
                     .filter(&extract_user_or_reject(mock_pg_pool))
@@ -146,7 +146,7 @@ mod test {
                 let path = $path;
                 $(let path = format!("{}?{}", path, $query);)*
 
-                let mock_pg_pool = PostgresPool::new();
+                let mock_pg_pool = PgPool::new();
                 warp::test::request()
                     .path(&path)
                     .header("Authorization", "Bearer: INVALID")
@@ -165,7 +165,7 @@ mod test {
             fn $name() {
                 let path = $path;
                 $(let path = format!("{}?{}", path, $query);)*
-                let mock_pg_pool = PostgresPool::new();
+                let mock_pg_pool = PgPool::new();
                 warp::test::request()
                     .path(&path)
                     .filter(&extract_user_or_reject(mock_pg_pool))
@@ -180,7 +180,7 @@ mod test {
             target_timeline: "public:media".to_string(),
             id: -1,
             email: "".to_string(),
-            access_token: "no access token".to_string(),
+            access_token: "".to_string(),
             langs: None,
             scopes: OauthScope {
                 all: false,
@@ -189,6 +189,7 @@ mod test {
                 lists: false,
             },
             logged_in: false,
+            blocks: Blocks::default(),
             filter: Filter::Language,
         },
     });
@@ -198,7 +199,7 @@ mod test {
             target_timeline: "public:media".to_string(),
             id: -1,
             email: "".to_string(),
-            access_token: "no access token".to_string(),
+            access_token: "".to_string(),
             langs: None,
             scopes: OauthScope {
                 all: false,
@@ -207,6 +208,7 @@ mod test {
                 lists: false,
             },
             logged_in: false,
+            blocks: Blocks::default(),
             filter: Filter::Language,
         },
     });
@@ -216,7 +218,7 @@ mod test {
             target_timeline: "public:local".to_string(),
             id: -1,
             email: "".to_string(),
-            access_token: "no access token".to_string(),
+            access_token: "".to_string(),
             langs: None,
             scopes: OauthScope {
                 all: false,
@@ -225,6 +227,7 @@ mod test {
                 lists: false,
             },
             logged_in: false,
+            blocks: Blocks::default(),
             filter: Filter::Language,
         },
     });
@@ -234,7 +237,7 @@ mod test {
             target_timeline: "public:local:media".to_string(),
             id: -1,
             email: "".to_string(),
-            access_token: "no access token".to_string(),
+            access_token: "".to_string(),
             langs: None,
             scopes: OauthScope {
                 all: false,
@@ -243,6 +246,7 @@ mod test {
                 lists: false,
             },
             logged_in: false,
+            blocks: Blocks::default(),
             filter: Filter::Language,
         },
     });
@@ -252,7 +256,7 @@ mod test {
             target_timeline: "public:local:media".to_string(),
             id: -1,
             email: "".to_string(),
-            access_token: "no access token".to_string(),
+            access_token: "".to_string(),
             langs: None,
             scopes: OauthScope {
                 all: false,
@@ -261,6 +265,7 @@ mod test {
                 lists: false,
             },
             logged_in: false,
+            blocks: Blocks::default(),
             filter: Filter::Language,
         },
     });
@@ -270,7 +275,7 @@ mod test {
             target_timeline: "hashtag:a".to_string(),
             id: -1,
             email: "".to_string(),
-            access_token: "no access token".to_string(),
+            access_token: "".to_string(),
             langs: None,
             scopes: OauthScope {
                 all: false,
@@ -279,6 +284,7 @@ mod test {
                 lists: false,
             },
             logged_in: false,
+            blocks: Blocks::default(),
             filter: Filter::Language,
         },
     });
@@ -288,7 +294,7 @@ mod test {
             target_timeline: "hashtag:local:a".to_string(),
             id: -1,
             email: "".to_string(),
-            access_token: "no access token".to_string(),
+            access_token: "".to_string(),
             langs: None,
             scopes: OauthScope {
                 all: false,
@@ -297,6 +303,7 @@ mod test {
                 lists: false,
             },
             logged_in: false,
+            blocks: Blocks::default(),
             filter: Filter::Language,
         },
     });
@@ -316,6 +323,7 @@ mod test {
                 lists: false,
             },
             logged_in: true,
+            blocks: Blocks::default(),
             filter: Filter::NoFilter,
         },
     });
@@ -334,6 +342,7 @@ mod test {
                 lists: false,
             },
             logged_in: true,
+            blocks: Blocks::default(),
             filter: Filter::Notification,
         },
     });
@@ -352,6 +361,7 @@ mod test {
                 lists: false,
             },
             logged_in: true,
+            blocks: Blocks::default(),
             filter: Filter::NoFilter,
         },
     });
@@ -372,6 +382,7 @@ mod test {
                 lists: false,
             },
             logged_in: true,
+            blocks: Blocks::default(),
             filter: Filter::NoFilter,
         },
     });
@@ -448,7 +459,7 @@ mod test {
     #[test]
     #[should_panic(expected = "NotFound")]
     fn nonexistant_endpoint() {
-        let mock_pg_pool = PostgresPool::new();
+        let mock_pg_pool = PgPool::new();
         warp::test::request()
             .path("/api/v1/streaming/DOES_NOT_EXIST")
             .filter(&extract_user_or_reject(mock_pg_pool))

--- a/src/parse_client_request/sse.rs
+++ b/src/parse_client_request/sse.rs
@@ -1,7 +1,7 @@
 //! Filters for all the endpoints accessible for Server Sent Event updates
 use super::{
     query::{self, Query},
-    user::{PostgresPool, User},
+    user::{PgPool, User},
 };
 use warp::{filters::BoxedFilter, path, Filter};
 #[allow(dead_code)]
@@ -39,7 +39,7 @@ macro_rules! parse_query {
             .boxed()
     };
 }
-pub fn extract_user_or_reject(pg_pool: PostgresPool) -> BoxedFilter<(User,)> {
+pub fn extract_user_or_reject(pg_pool: PgPool) -> BoxedFilter<(User,)> {
     any_of!(
         parse_query!(
             path => "api" / "v1" / "streaming" / "user" / "notification"

--- a/src/parse_client_request/user/mock_postgres.rs
+++ b/src/parse_client_request/user/mock_postgres.rs
@@ -1,5 +1,6 @@
 //! Mock Postgres connection (for use in unit testing)
 use super::{OauthScope, User};
+use std::collections::HashSet;
 
 #[derive(Clone)]
 pub struct PgPool;
@@ -27,11 +28,11 @@ pub fn select_user(access_token: &str, _pg_pool: PgPool) -> Result<User, warp::r
     Ok(user)
 }
 
-pub fn select_user_blocks(_id: i64, _pg_pool: PgPool) -> Vec<i64> {
-    Vec::new()
+pub fn select_user_blocks(_id: i64, _pg_pool: PgPool) -> HashSet<i64> {
+    HashSet::new()
 }
-pub fn select_domain_blocks(_pg_pool: PgPool) -> Vec<String> {
-    Vec::new()
+pub fn select_domain_blocks(_pg_pool: PgPool) -> HashSet<String> {
+    HashSet::new()
 }
 
 pub fn user_owns_list(user_id: i64, list_id: i64, _pg_pool: PgPool) -> bool {

--- a/src/parse_client_request/user/mock_postgres.rs
+++ b/src/parse_client_request/user/mock_postgres.rs
@@ -1,37 +1,39 @@
 //! Mock Postgres connection (for use in unit testing)
+use super::{OauthScope, User};
 
 #[derive(Clone)]
-pub struct PostgresPool;
-impl PostgresPool {
+pub struct PgPool;
+impl PgPool {
     pub fn new() -> Self {
         Self
     }
 }
 
-pub fn query_for_user_data(
-    access_token: &str,
-    _pg_pool: PostgresPool,
-) -> (i64, String, Option<Vec<String>>, Vec<String>) {
-    let (user_id, email, lang, scopes) = if access_token == "TEST_USER" {
-        (
-            1,
-            "user@example.com".to_string(),
-            None,
-            vec![
-                "read".to_string(),
-                "write".to_string(),
-                "follow".to_string(),
-            ],
-        )
-    } else {
-        (-1, "".to_string(), None, Vec::new())
-    };
-    (user_id, email, lang, scopes)
+pub fn select_user(access_token: &str, _pg_pool: PgPool) -> Result<User, warp::reject::Rejection> {
+    let mut user = User::default();
+    if access_token == "TEST_USER" {
+        user.id = 1;
+        user.logged_in = true;
+        user.access_token = "TEST_USER".to_string();
+        user.email = "user@example.com".to_string();
+        user.scopes = OauthScope::from(vec![
+            "read".to_string(),
+            "write".to_string(),
+            "follow".to_string(),
+        ]);
+    } else if access_token == "INVALID" {
+        return Err(warp::reject::custom("Error: Invalid access token"));
+    }
+    Ok(user)
 }
 
-pub fn query_list_owner(list_id: i64, _pg_pool: PostgresPool) -> Option<i64> {
-    match list_id {
-        1 => Some(1),
-        _ => None,
-    }
+pub fn select_user_blocks(_id: i64, _pg_pool: PgPool) -> Vec<i64> {
+    Vec::new()
+}
+pub fn select_domain_blocks(_pg_pool: PgPool) -> Vec<String> {
+    Vec::new()
+}
+
+pub fn user_owns_list(user_id: i64, list_id: i64, _pg_pool: PgPool) -> bool {
+    user_id == list_id
 }

--- a/src/parse_client_request/user/mod.rs
+++ b/src/parse_client_request/user/mod.rs
@@ -5,7 +5,7 @@ mod mock_postgres;
 use mock_postgres as postgres;
 #[cfg(not(test))]
 mod postgres;
-pub use self::postgres::PostgresPool as PgPool;
+pub use self::postgres::PgPool;
 use super::query::Query;
 use warp::reject::Rejection;
 
@@ -18,7 +18,7 @@ pub enum Filter {
 }
 impl Default for Filter {
     fn default() -> Self {
-        Filter::NoFilter
+        Filter::Language
     }
 }
 

--- a/src/parse_client_request/user/postgres.rs
+++ b/src/parse_client_request/user/postgres.rs
@@ -8,8 +8,8 @@ use r2d2_postgres::PostgresConnectionManager;
 use warp::reject::Rejection;
 
 #[derive(Clone)]
-pub struct PostgresPool(pub r2d2::Pool<PostgresConnectionManager<postgres::NoTls>>);
-impl PostgresPool {
+pub struct PgPool(pub r2d2::Pool<PostgresConnectionManager<postgres::NoTls>>);
+impl PgPool {
     pub fn new(pg_cfg: config::PostgresConfig) -> Self {
         let mut cfg = postgres::Config::new();
         cfg.user(&pg_cfg.user)
@@ -33,7 +33,7 @@ impl PostgresPool {
 ///
 /// This does _not_ set the timeline, filter, or blocks fields.  Use the various `User`
 /// methods to do so.  In general, this function shouldn't be needed outside `User`.
-pub fn select_user(access_token: &str, pg_pool: PostgresPool) -> Result<User, Rejection> {
+pub fn select_user(access_token: &str, pg_pool: PgPool) -> Result<User, Rejection> {
     let mut conn = pg_pool.0.get().unwrap();
     let query_result = conn
             .query(
@@ -91,7 +91,7 @@ pub fn query_for_user_data(access_token: &str) -> (i64, Option<Vec<String>>, Vec
 ///
 /// **NOTE**: because we check this when the user connects, it will not include any blocks
 /// the user adds until they refresh/reconnect.
-pub fn select_user_blocks(user_id: i64, pg_pool: PostgresPool) -> Vec<i64> {
+pub fn select_user_blocks(user_id: i64, pg_pool: PgPool) -> Vec<i64> {
     pg_pool
         .0
         .get()
@@ -117,7 +117,7 @@ UNION SELECT target_account_id
 /// **NOTE**: because we check this when the user connects, it will not include any blocks
 /// the user adds until they refresh/reconnect.  Additionally, we are querying it once per
 /// user, even though it is constant for all users (at any given time).
-pub fn select_domain_blocks(pg_pool: PostgresPool) -> Vec<String> {
+pub fn select_domain_blocks(pg_pool: PgPool) -> Vec<String> {
     pg_pool
         .0
         .get()
@@ -130,7 +130,7 @@ pub fn select_domain_blocks(pg_pool: PostgresPool) -> Vec<String> {
 }
 
 /// Test whether a user owns a list
-pub fn user_owns_list(user_id: i64, list_id: i64, pg_pool: PostgresPool) -> bool {
+pub fn user_owns_list(user_id: i64, list_id: i64, pg_pool: PgPool) -> bool {
     let mut conn = pg_pool.0.get().unwrap();
     // For the Postgres query, `id` = list number; `account_id` = user.id
     let rows = &conn

--- a/src/parse_client_request/user/postgres.rs
+++ b/src/parse_client_request/user/postgres.rs
@@ -99,14 +99,13 @@ UNION SELECT target_account_id
 /// Query Postgres for all current domain blocks
 ///
 /// **NOTE**: because we check this when the user connects, it will not include any blocks
-/// the user adds until they refresh/reconnect.  Additionally, we are querying it once per
-/// user, even though it is constant for all users (at any given time).
+/// the user adds until they refresh/reconnect.
 pub fn select_domain_blocks(pg_pool: PgPool) -> HashSet<String> {
     pg_pool
         .0
         .get()
         .unwrap()
-        .query("SELECT domain FROM domain_blocks", &[])
+        .query("SELECT domain FROM account_domain_blocks", &[])
         .expect("Hard-coded query will return Some([0 or more rows])")
         .iter()
         .map(|row| row.get(0))

--- a/src/parse_client_request/ws.rs
+++ b/src/parse_client_request/ws.rs
@@ -43,7 +43,7 @@ pub fn extract_user_or_reject(pg_pool: PgPool) -> BoxedFilter<(User,)> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::parse_client_request::user::{Filter, OauthScope};
+    use crate::parse_client_request::user::{Blocks, Filter, OauthScope};
 
     macro_rules! test_public_endpoint {
         ($name:ident {
@@ -52,7 +52,7 @@ mod test {
         }) => {
             #[test]
             fn $name() {
-                let mock_pg_pool = PostgresPool::new();
+                let mock_pg_pool = PgPool::new();
                 let user = warp::test::request()
                     .path($path)
                     .header("connection", "upgrade")
@@ -72,7 +72,7 @@ mod test {
         }) => {
             #[test]
             fn $name() {
-                let mock_pg_pool = PostgresPool::new();
+                let mock_pg_pool = PgPool::new();
                 let path = format!("{}&access_token=TEST_USER", $path);
                 let user = warp::test::request()
                     .path(&path)
@@ -96,7 +96,7 @@ mod test {
 
             fn $name() {
                 let path = format!("{}&access_token=INVALID", $path);
-                let mock_pg_pool = PostgresPool::new();
+                let mock_pg_pool = PgPool::new();
                 warp::test::request()
                     .path(&path)
                     .filter(&extract_user_or_reject(mock_pg_pool))
@@ -112,7 +112,7 @@ mod test {
             #[should_panic(expected = "Error: Missing access token")]
             fn $name() {
                 let path = $path;
-                let mock_pg_pool = PostgresPool::new();
+                let mock_pg_pool = PgPool::new();
                 warp::test::request()
                     .path(&path)
                     .filter(&extract_user_or_reject(mock_pg_pool))
@@ -127,7 +127,7 @@ mod test {
             target_timeline: "public:media".to_string(),
             id: -1,
             email: "".to_string(),
-            access_token: "no access token".to_string(),
+            access_token: "".to_string(),
             langs: None,
             scopes: OauthScope {
                 all: false,
@@ -136,6 +136,7 @@ mod test {
                 lists: false,
             },
             logged_in: false,
+            blocks: Blocks::default(),
             filter: Filter::Language,
         },
     });
@@ -145,7 +146,7 @@ mod test {
             target_timeline: "public:local".to_string(),
             id: -1,
             email: "".to_string(),
-            access_token: "no access token".to_string(),
+            access_token: "".to_string(),
             langs: None,
             scopes: OauthScope {
                 all: false,
@@ -154,6 +155,7 @@ mod test {
                 lists: false,
             },
             logged_in: false,
+            blocks: Blocks::default(),
             filter: Filter::Language,
         },
     });
@@ -163,7 +165,7 @@ mod test {
             target_timeline: "public:local:media".to_string(),
             id: -1,
             email: "".to_string(),
-            access_token: "no access token".to_string(),
+            access_token: "".to_string(),
             langs: None,
             scopes: OauthScope {
                 all: false,
@@ -172,6 +174,7 @@ mod test {
                 lists: false,
             },
             logged_in: false,
+            blocks: Blocks::default(),
             filter: Filter::Language,
         },
     });
@@ -181,7 +184,7 @@ mod test {
             target_timeline: "hashtag:a".to_string(),
             id: -1,
             email: "".to_string(),
-            access_token: "no access token".to_string(),
+            access_token: "".to_string(),
             langs: None,
             scopes: OauthScope {
                 all: false,
@@ -190,6 +193,7 @@ mod test {
                 lists: false,
             },
             logged_in: false,
+            blocks: Blocks::default(),
             filter: Filter::Language,
         },
     });
@@ -199,7 +203,7 @@ mod test {
             target_timeline: "hashtag:local:a".to_string(),
             id: -1,
             email: "".to_string(),
-            access_token: "no access token".to_string(),
+            access_token: "".to_string(),
             langs: None,
             scopes: OauthScope {
                 all: false,
@@ -208,6 +212,7 @@ mod test {
                 lists: false,
             },
             logged_in: false,
+            blocks: Blocks::default(),
             filter: Filter::Language,
         },
     });
@@ -227,6 +232,7 @@ mod test {
                 lists: false,
             },
             logged_in: true,
+            blocks: Blocks::default(),
             filter: Filter::NoFilter,
         },
     });
@@ -245,6 +251,7 @@ mod test {
                 lists: false,
             },
             logged_in: true,
+            blocks: Blocks::default(),
             filter: Filter::Notification,
         },
     });
@@ -263,6 +270,7 @@ mod test {
                 lists: false,
             },
             logged_in: true,
+            blocks: Blocks::default(),
             filter: Filter::NoFilter,
         },
     });
@@ -281,6 +289,7 @@ mod test {
                 lists: false,
             },
             logged_in: true,
+            blocks: Blocks::default(),
             filter: Filter::NoFilter,
         },
     });
@@ -325,7 +334,7 @@ mod test {
     #[test]
     #[should_panic(expected = "NotFound")]
     fn nonexistant_endpoint() {
-        let mock_pg_pool = PostgresPool::new();
+        let mock_pg_pool = PgPool::new();
         warp::test::request()
             .path("/api/v1/streaming/DOES_NOT_EXIST")
             .header("connection", "upgrade")

--- a/src/parse_client_request/ws.rs
+++ b/src/parse_client_request/ws.rs
@@ -1,7 +1,7 @@
 //! Filters for the WebSocket endpoint
 use super::{
     query::{self, Query},
-    user::{PostgresPool, User},
+    user::{PgPool, User},
 };
 use warp::{filters::BoxedFilter, path, Filter};
 
@@ -32,7 +32,7 @@ fn parse_query() -> BoxedFilter<(Query,)> {
         .boxed()
 }
 
-pub fn extract_user_or_reject(pg_pool: PostgresPool) -> BoxedFilter<(User,)> {
+pub fn extract_user_or_reject(pg_pool: PgPool) -> BoxedFilter<(User,)> {
     parse_query()
         .and(query::OptionalAccessToken::from_ws_header())
         .and_then(Query::update_access_token)

--- a/src/redis_to_client_stream/client_agent.rs
+++ b/src/redis_to_client_stream/client_agent.rs
@@ -134,6 +134,21 @@ impl Toot {
         }
     }
 
+    pub fn get_originating_domain(&self) -> HashSet<String> {
+        let api = "originating  Invariant Violation: JSON value does not conform to Mastdon API";
+        let mut originating_domain = HashSet::new();
+        originating_domain.insert(
+            self.payload["account"]["acct"]
+                .as_str()
+                .expect(&api)
+                .split("@")
+                .nth(1)
+                .expect(&api)
+                .to_string(),
+        );
+        originating_domain
+    }
+
     pub fn get_involved_users(&self) -> HashSet<i64> {
         let mut involved_users: HashSet<i64> = HashSet::new();
         let msg = self.payload.clone();

--- a/src/redis_to_client_stream/mod.rs
+++ b/src/redis_to_client_stream/mod.rs
@@ -82,17 +82,20 @@ pub fn send_updates_to_ws(
 
     let mut time = time::Instant::now();
 
-    let (tl, email, id, blocked_users) = (
+    let (tl, email, id, blocked_users, blocked_domains) = (
         client_agent.current_user.target_timeline.clone(),
         client_agent.current_user.email.clone(),
         client_agent.current_user.id,
         client_agent.current_user.blocks.user_blocks.clone(),
+        client_agent.current_user.blocks.domain_blocks.clone(),
     );
     // Every time you get an event from that stream, send it through the pipe
     event_stream
         .for_each(move |_instant| {
             if let Ok(Async::Ready(Some(toot))) = client_agent.poll() {
-                if blocked_users.is_disjoint(&toot.get_involved_users()) {
+                if blocked_domains.is_disjoint(&toot.get_originating_domain())
+                    && blocked_users.is_disjoint(&toot.get_involved_users())
+                {
                     let txt = &toot.payload["content"];
                     log::warn!("toot: {}\nTL: {}\nUser: {}({})", txt, tl, email, id);
 

--- a/src/redis_to_client_stream/mod.rs
+++ b/src/redis_to_client_stream/mod.rs
@@ -82,29 +82,33 @@ pub fn send_updates_to_ws(
 
     let mut time = time::Instant::now();
 
-    let (tl, email, id) = (
+    let (tl, email, id, blocked_users) = (
         client_agent.current_user.target_timeline.clone(),
         client_agent.current_user.email.clone(),
         client_agent.current_user.id,
+        client_agent.current_user.blocks.user_blocks.clone(),
     );
     // Every time you get an event from that stream, send it through the pipe
     event_stream
         .for_each(move |_instant| {
             if let Ok(Async::Ready(Some(toot))) = client_agent.poll() {
-                let txt = &toot.payload["content"];
-                log::warn!("toot: {}\n in TL: {}\nuser: {}({})", txt, tl, email, id);
+                if blocked_users.is_disjoint(&toot.get_involved_users()) {
+                    let txt = &toot.payload["content"];
+                    log::warn!("toot: {}\nTL: {}\nUser: {}({})", txt, tl, email, id);
 
-                let msg = warp::ws::Message::text(
-                    json!({"event": toot.category,
-                           "payload": toot.payload.to_string()})
-                    .to_string(),
-                );
-
-                tx.unbounded_send(msg).expect("No send error");
+                    tx.unbounded_send(warp::ws::Message::text(
+                        json!({ "event": toot.category,
+                                "payload": &toot.payload.to_string() })
+                        .to_string(),
+                    ))
+                    .expect("No send error");
+                } else {
+                    log::info!("Blocked a message to {}", email);
+                }
             };
             if time.elapsed() > time::Duration::from_secs(30) {
-                let msg = warp::ws::Message::text("{}");
-                tx.unbounded_send(msg).expect("Can ping");
+                tx.unbounded_send(warp::ws::Message::text("{}"))
+                    .expect("Can ping");
                 time = time::Instant::now();
             }
             Ok(())


### PR DESCRIPTION
This PR filters toots that mention, boost, or are from an account that the user has blocked or muted or that are from a domain the user has blocked.

As described in the code comments, this PR checks blocks when the user connects to a stream, so blocks are not updated until the user reconnects (i.e., refreshes or re-navigates between timelines).

Closes #88 