### PR TITLE
Double-escaping of delete payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flodgatt"
-version = "0.5.0"
+version = "0.6.1"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flodgatt"
 description = "A blazingly fast drop-in replacement for the Mastodon streaming api server"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Daniel Long Sockwell <daniel@codesections.com", "Julian Laubstein <contact@julianlaubstein.de>"]
 edition = "2018"
 

--- a/src/redis_to_client_stream/message.rs
+++ b/src/redis_to_client_stream/message.rs
@@ -25,7 +25,12 @@ impl Message {
             "update" => Self::Update(Status(json["payload"].clone())),
             "conversation" => Self::Conversation(json["payload"].clone()),
             "notification" => Self::Notification(json["payload"].clone()),
-            "delete" => Self::Delete(json["payload"].to_string()),
+            "delete" => Self::Delete(
+                json["payload"]
+                    .as_str()
+                    .unwrap_or_else(|| log_fatal!("Could not process `payload` in {:?}", json))
+                    .to_string(),
+            ),
             "filters_changed" => Self::FiltersChanged,
             unsupported_event => log_fatal!(
                 "Received an unsupported `event` type from Redis: {}",


### PR DESCRIPTION
This PR fixes an issue that caused the delete payload to be converted to a String twice, which resulted in messages like `{"event":"delete","payload":"\"103846522492813198\""}` instead of `{"event":"delete","payload":"103846522492813198"}`