### PR TITLE
Add support for announcement event type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flodgatt"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flodgatt"
 description = "A blazingly fast drop-in replacement for the Mastodon streaming api server"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Daniel Long Sockwell <daniel@codesections.com", "Julian Laubstein <contact@julianlaubstein.de>"]
 edition = "2018"
 

--- a/src/redis_to_client_stream/client_agent.rs
+++ b/src/redis_to_client_stream/client_agent.rs
@@ -117,6 +117,8 @@ impl futures::stream::Stream for ClientAgent {
                 Conversation(notification) => send(Conversation(notification)),
                 Delete(status_id) => send(Delete(status_id)),
                 FiltersChanged => send(FiltersChanged),
+                Announcement(content) => send(Announcement(content)),
+                UnknownEvent(event, payload) => send(UnknownEvent(event, payload)),
             },
             Ok(Ready(None)) => Ok(Ready(None)),
             Ok(NotReady) => Ok(NotReady),


### PR DESCRIPTION
This PR adds support for the `announcement`, `announcement.delete`, and `announcement.reaction` event types.  It also adds a catch-all `UnknownEvent` event type that logs a warning instead of causing a panic.