### PR TITLE
Stop filtering out toots with language set to `""`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flodgatt"
 description = "A blazingly fast drop-in replacement for the Mastodon streaming api server"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["Daniel Long Sockwell <daniel@codesections.com", "Julian Laubstein <contact@julianlaubstein.de>"]
 edition = "2018"
 

--- a/src/redis_to_client_stream/message.rs
+++ b/src/redis_to_client_stream/message.rs
@@ -102,8 +102,8 @@ impl Status {
         }
         match self.0["language"].as_str() {
             Some(toot_language) if allowed_langs.contains(toot_language) => ALLOW,
+            None | Some("") => ALLOW, // If toot language is unknown, toot is always allowed
             Some(toot_language) => reject_and_maybe_log(toot_language),
-            None => ALLOW, // If toot language is null, toot is always allowed
         }
     }
 


### PR DESCRIPTION
Previously, if a toot's language was `null`, then it would be permitted regardless of the user's language filter; however, if it were `""` (the empty string) it was rejected.  Now, the empty string is treated like `null` and the toot is allowed.