### PR TITLE
Fix `DATABASE_URL` parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flodgatt"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -460,6 +460,7 @@ dependencies = [
  "strum_macros 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "urlencoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "warp 0.1.20 (git+https://github.com/seanmonstar/warp.git)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ strum_macros = "0.16.0"
 r2d2_postgres = "0.16.0"
 r2d2 = "0.8.8"
 lru = "0.4.3"
+urlencoding = "1.0.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/config/postgres_cfg.rs
+++ b/src/config/postgres_cfg.rs
@@ -1,5 +1,6 @@
 use super::{postgres_cfg_types::*, EnvVar};
 use url::Url;
+use urlencoding;
 
 #[derive(Debug)]
 pub struct PostgresConfig {
@@ -32,6 +33,12 @@ impl EnvVar {
 
         self.maybe_add_env_var("DB_PORT", url.port());
         self.maybe_add_env_var("DB_PASS", url.password());
+        self.maybe_add_env_var(
+            "DB_HOST",
+            url.host().map(|h| {
+                urlencoding::decode(&h.to_string()).expect("Non-Unicode text in hostname")
+            }),
+        );
         self.maybe_add_env_var("DB_USER", none_if_empty(url.username().to_string()));
         self.maybe_add_env_var("DB_NAME", none_if_empty(url.path()[1..].to_string()));
 


### PR DESCRIPTION
This PR adds support for specifying the host directly in the `DATABASE_URL` path, in addition to via a query parameter. (Or with the `DB_HOST` variable).  This includes passing a URL-escaped hostname.