### PR TITLE
Stub status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flodgatt"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flodgatt"
 description = "A blazingly fast drop-in replacement for the Mastodon streaming api server"
-version = "0.6.8"
+version = "0.7.0"
 authors = ["Daniel Long Sockwell <daniel@codesections.com", "Julian Laubstein <contact@julianlaubstein.de>"]
 edition = "2018"
 
@@ -38,4 +38,5 @@ harness = false
 [features]
 default = [ "production" ]
 bench = []
+stub_status = []
 production = []

--- a/src/redis_to_client_stream/receiver/mod.rs
+++ b/src/redis_to_client_stream/receiver/mod.rs
@@ -107,6 +107,37 @@ impl Receiver {
         }
     }
 
+    pub fn count_connections(&self) -> String {
+        format!(
+            "Current connections: {}",
+            self.clients_per_timeline.values().sum::<i32>()
+        )
+    }
+
+    pub fn list_connections(&self) -> String {
+        let max_len = self
+            .clients_per_timeline
+            .keys()
+            .fold(0, |acc, el| acc.max(format!("{:?}:", el).len()));
+        self.clients_per_timeline
+            .iter()
+            .map(|(tl, n)| {
+                let tl_txt = format!("{:?}:", tl);
+                format!("{:>1$} {2}\n", tl_txt, max_len, n)
+            })
+            .collect()
+    }
+
+    pub fn queue_length(&self) -> String {
+        format!(
+            "Longest MessageQueue: {}",
+            self.msg_queues
+                .0
+                .values()
+                .fold(0, |acc, el| acc.max(el.messages.len()))
+        )
+    }
+
     /// Drop any PubSub subscriptions that don't have active clients and check
     /// that there's a subscription to the current one.  If there isn't, then
     /// subscribe to it.


### PR DESCRIPTION
This PR enables compiling Flodgatt with the `stub_status` feature.  When compiled with `stub_status`, Flodgatt has 3 new API endpoints:  `/api/v1/streaming/status`, `/api/v1/streaming/status/per_timeline`, and `/api/v1/streaming/status/queue`.  The first endpoint lists the total number of connections, the second lists the number of connections per timeline, and the third lists the length of the longest queue of unsent messages (which should be low or zero when Flodgatt is functioning normally).

Note that the number of _connections_ is not equal to the number of connected _clients_.  If a user is viewing the local timeline, they would have at least two connections: one for the local timeline, and
one for their user timeline.  Other users could have even more connections.

I decided to make the status endpoints an option you enable at compile time rather than at run time for three reasons:

  * It keeps the API of the default version of Flodgatt 100%
    compatible with the Node server's API;
  * I don't believe it's an option Flodgatt administrators will want to
    toggle on and off frequently.
  * Using a compile time option ensures that there is zero runtime
    cost when the option is disabled.  (The runtime cost should be
    negligible either way, but there is value in being 100% sure that
    the cost can be eliminated.)

However, I'm happy to make it a runtime option instead if other think that would be helpful.