### PR TITLE
Iowait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,10 @@ regex = "1.3.2"
 name = "parse_redis"
 harness = false
 
+[[bench]]
+name = "bench_instant"
+harness = false
+
 
 [features]
 default = [ "production" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flodgatt"
 description = "A blazingly fast drop-in replacement for the Mastodon streaming api server"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Daniel Long Sockwell <daniel@codesections.com", "Julian Laubstein <contact@julianlaubstein.de>"]
 edition = "2018"
 
@@ -32,10 +32,6 @@ regex = "1.3.2"
 
 [[bench]]
 name = "parse_redis"
-harness = false
-
-[[bench]]
-name = "bench_instant"
 harness = false
 
 

--- a/src/config/environmental_variables.rs
+++ b/src/config/environmental_variables.rs
@@ -60,6 +60,7 @@ impl fmt::Display for EnvVar {
             "REDIS_PASSWORD",
             "REDIS_USER",
             "REDIS_DB",
+            "REDIS_FREQ",
         ]
         .iter()
         {

--- a/src/config/redis_cfg.rs
+++ b/src/config/redis_cfg.rs
@@ -59,7 +59,7 @@ For similar functionality, you may wish to set a REDIS_NAMESPACE";
             host: RedisHost::default().maybe_update(env.get("REDIS_HOST")),
             db: RedisDb::default().maybe_update(env.get("REDIS_DB")),
             namespace: RedisNamespace::default().maybe_update(env.get("REDIS_NAMESPACE")),
-            polling_interval: RedisInterval::default().maybe_update(env.get("REDIS_POLL_INTERVAL")),
+            polling_interval: RedisInterval::default().maybe_update(env.get("REDIS_FREQ")),
         };
 
         if cfg.db.is_some() {

--- a/src/config/redis_cfg_types.rs
+++ b/src/config/redis_cfg_types.rs
@@ -21,7 +21,7 @@ from_env_var!(
     /// How frequently to poll Redis
     let name = RedisInterval;
     let default: Duration = Duration::from_millis(100);
-    let (env_var, allowed_values) = ("REDIS_POLL_INTERVAL", "a number of milliseconds");
+    let (env_var, allowed_values) = ("REDIS_FREQ", "a number of milliseconds");
     let from_str = |s| s.parse().map(Duration::from_millis).ok();
 );
 from_env_var!(

--- a/src/redis_to_client_stream/client_agent.rs
+++ b/src/redis_to_client_stream/client_agent.rs
@@ -56,6 +56,14 @@ impl ClientAgent {
             .unwrap_or_else(|e| log::error!("Could not subscribe to the Redis channel: {}", e))
     }
 
+    pub fn disconnect(&self) -> futures::future::FutureResult<bool, tokio::timer::Error> {
+        let mut receiver = self.lock_receiver();
+        receiver
+            .remove_subscription(&self.subscription)
+            .unwrap_or_else(|e| log::error!("Could not unsubscribe from: {}", e));
+        futures::future::ok(false)
+    }
+
     fn lock_receiver(&self) -> MutexGuard<Receiver> {
         match self.receiver.lock() {
             Ok(inner) => inner,

--- a/src/redis_to_client_stream/event_stream.rs
+++ b/src/redis_to_client_stream/event_stream.rs
@@ -17,17 +17,17 @@ impl EventStream {
         mut client_agent: ClientAgent,
         interval: Duration,
     ) -> impl Future<Item = (), Error = ()> {
-        let (ws_tx, mut ws_rx) = ws.split();
+        let (transmit_to_ws, _receive_from_ws) = ws.split();
         let timeline = client_agent.subscription.timeline;
 
         // Create a pipe
         let (tx, rx) = futures::sync::mpsc::unbounded();
 
         // Send one end of it to a different thread and tell that end to forward whatever it gets
-        // on to the websocket client
+        // on to the WebSocket client
         warp::spawn(
             rx.map_err(|()| -> warp::Error { unreachable!() })
-                .forward(ws_tx)
+                .forward(transmit_to_ws)
                 .map(|_r| ())
                 .map_err(|e| match e.to_string().as_ref() {
                     "IO error: Broken pipe (os error 32)" => (), // just closed unix socket
@@ -35,50 +35,42 @@ impl EventStream {
                 }),
         );
 
-        // Yield new events for as long as the client is still connected
-        let event_stream =
-            tokio::timer::Interval::new(Instant::now(), interval).take_while(move |_| {
-                match ws_rx.poll() {
-                    Ok(Async::NotReady) | Ok(Async::Ready(Some(_))) => futures::future::ok(true),
-                    Ok(Async::Ready(None)) => {
-                        log::info!("Client closed WebSocket connection for {:?}", timeline);
-                        futures::future::ok(false)
-                    }
-                    Err(e) if e.to_string() == "IO error: Broken pipe (os error 32)" => {
-                        // no err, just closed Unix socket
-                        log::info!("Client closed WebSocket connection for {:?}", timeline);
-                        futures::future::ok(false)
-                    }
-                    Err(e) => {
-                        log::warn!("Error in {:?}: {}", timeline, e);
-                        futures::future::ok(false)
-                    }
-                }
-            });
-
         let mut last_ping_time = Instant::now();
-        // Every time you get an event from that stream, send it through the pipe
-        event_stream
-            .for_each(move |_instant| {
+        tokio::timer::Interval::new(Instant::now(), interval)
+            .take_while(move |_| {
+                // Right now, we do not need to see if we have any messages _from_ the
+                // WebSocket connection because the API doesn't support clients sending
+                // commands via the WebSocket.  However, if the [stream multiplexing API
+                // change](github.com/tootsuite/flodgatt/issues/121) is implemented, we'll
+                // need to receive messages from the client.  If so, we'll need a
+                // `receive_from_ws.poll() call here (or later)`
+
                 match client_agent.poll() {
                     Ok(Async::Ready(Some(msg))) => {
-                        tx.unbounded_send(Message::text(msg.to_json_string()))
-                            .unwrap_or_else(|e| {
-                                log::error!("Could not send message to WebSocket: {}", e)
-                            });
+                        match tx.unbounded_send(Message::text(msg.to_json_string())) {
+                            Ok(_) => futures::future::ok(true),
+                            Err(_) => client_agent.disconnect(),
+                        }
                     }
-                    Ok(Async::Ready(None)) => log::info!("WebSocket ClientAgent got Ready(None)"),
+                    Ok(Async::Ready(None)) => {
+                        log::info!("WebSocket ClientAgent got Ready(None)");
+                        futures::future::ok(true)
+                    }
                     Ok(Async::NotReady) if last_ping_time.elapsed() > Duration::from_secs(30) => {
-                        tx.unbounded_send(Message::text("{}")).unwrap_or_else(|e| {
-                            log::error!("Could not send ping to WebSocket: {}", e)
-                        });
                         last_ping_time = Instant::now();
+                        match tx.unbounded_send(Message::text("{}")) {
+                            Ok(_) => futures::future::ok(true),
+                            Err(_) => client_agent.disconnect(),
+                        }
                     }
-                    Ok(Async::NotReady) => (), // no new messages; nothing to do
-                    Err(e) => log::error!("{}\n Dropping WebSocket message and continuing.", e),
+                    Ok(Async::NotReady) => futures::future::ok(true), // no new messages; nothing to do
+                    Err(e) => {
+                        log::error!("{}\n Dropping WebSocket message and continuing.", e);
+                        futures::future::ok(true)
+                    }
                 }
-                Ok(())
             })
+            .for_each(move |_instant| Ok(()))
             .then(move |result| {
                 log::info!("WebSocket connection for {:?} closed.", timeline);
                 result

--- a/src/redis_to_client_stream/receiver/message_queues.rs
+++ b/src/redis_to_client_stream/receiver/message_queues.rs
@@ -4,7 +4,6 @@ use crate::parse_client_request::Timeline;
 use std::{
     collections::{HashMap, VecDeque},
     fmt,
-    time::{Duration, Instant},
 };
 use uuid::Uuid;
 
@@ -12,19 +11,15 @@ use uuid::Uuid;
 pub struct MsgQueue {
     pub timeline: Timeline,
     pub messages: VecDeque<Event>,
-    last_polled_at: Instant,
 }
 
 impl MsgQueue {
     pub fn new(timeline: Timeline) -> Self {
         MsgQueue {
             messages: VecDeque::new(),
-            last_polled_at: Instant::now(),
+
             timeline,
         }
-    }
-    pub fn update_polled_at_time(&mut self) {
-        self.last_polled_at = Instant::now();
     }
 }
 
@@ -39,18 +34,20 @@ impl MessageQueues {
             timeline,
             in_subscriber_number: 1,
         });
-        self.retain(|_id, msg_queue| {
-            if msg_queue.last_polled_at.elapsed() < Duration::from_secs(30) {
-                true
-            } else {
-                let timeline = &msg_queue.timeline;
-                timelines_to_modify.push(Change {
-                    timeline: *timeline,
-                    in_subscriber_number: -1,
-                });
-                false
-            }
-        });
+
+        // self.retain(|_id, msg_queue| {
+        //     if msg_queue.last_polled_at.elapsed() < Duration::from_secs(30) {
+        //         true
+        //     } else {
+        //         let timeline = &msg_queue.timeline;
+        //         timelines_to_modify.push(Change {
+        //             timeline: *timeline,
+        //             in_subscriber_number: -1,
+        //         });
+        //         false
+        //     }
+        // });
+        // TODO: reimplement ^^^^
         timelines_to_modify
     }
 }
@@ -66,12 +63,9 @@ impl fmt::Debug for MsgQueue {
             "\
 MsgQueue {{
     timeline: {:?},
-    messages: {:?},
-    last_polled_at: {:?} ago,
+    messages: {:?},    
 }}",
-            self.timeline,
-            self.messages,
-            self.last_polled_at.elapsed(),
+            self.timeline, self.messages,
         )
     }
 }

--- a/src/redis_to_client_stream/receiver/message_queues.rs
+++ b/src/redis_to_client_stream/receiver/message_queues.rs
@@ -26,35 +26,7 @@ impl MsgQueue {
 #[derive(Debug)]
 pub struct MessageQueues(pub HashMap<Uuid, MsgQueue>);
 
-impl MessageQueues {
-    pub fn calculate_timelines_to_add_or_drop(&mut self, timeline: Timeline) -> Vec<Change> {
-        let mut timelines_to_modify = Vec::new();
-
-        timelines_to_modify.push(Change {
-            timeline,
-            in_subscriber_number: 1,
-        });
-
-        // self.retain(|_id, msg_queue| {
-        //     if msg_queue.last_polled_at.elapsed() < Duration::from_secs(30) {
-        //         true
-        //     } else {
-        //         let timeline = &msg_queue.timeline;
-        //         timelines_to_modify.push(Change {
-        //             timeline: *timeline,
-        //             in_subscriber_number: -1,
-        //         });
-        //         false
-        //     }
-        // });
-        // TODO: reimplement ^^^^
-        timelines_to_modify
-    }
-}
-pub struct Change {
-    pub timeline: Timeline,
-    pub in_subscriber_number: i32,
-}
+impl MessageQueues {}
 
 impl fmt::Debug for MsgQueue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/redis_to_client_stream/receiver/mod.rs
+++ b/src/redis_to_client_stream/receiver/mod.rs
@@ -92,13 +92,10 @@ impl Receiver {
 
         // If the `msg_queue` being polled has any new messages, return the first (oldest) one
         match self.msg_queues.get_mut(&id) {
-            Some(msg_q) => {
-                msg_q.update_polled_at_time();
-                match msg_q.messages.pop_front() {
-                    Some(event) => Ok(Async::Ready(Some(event))),
-                    None => Ok(Async::NotReady),
-                }
-            }
+            Some(msg_q) => match msg_q.messages.pop_front() {
+                Some(event) => Ok(Async::Ready(Some(event))),
+                None => Ok(Async::NotReady),
+            },
             None => {
                 log::error!("Polled a MsgQueue that had not been set up.  Setting it up now.");
                 self.msg_queues.insert(id, MsgQueue::new(timeline));

--- a/src/redis_to_client_stream/receiver/mod.rs
+++ b/src/redis_to_client_stream/receiver/mod.rs
@@ -90,8 +90,9 @@ impl Receiver {
             });
         use RedisCmd::*;
         if *number_of_subscriptions == 0 {
-            self.redis_connection.send_cmd(Unsubscribe, &tl)?
-        }
+            self.redis_connection.send_cmd(Unsubscribe, &tl)?;
+            self.clients_per_timeline.remove_entry(&tl);
+        };
 
         Ok(())
     }
@@ -163,31 +164,4 @@ impl Receiver {
                 .fold(0, |acc, el| acc.max(el.messages.len()))
         )
     }
-
-    // /// Drop any PubSub subscriptions that don't have active clients and check
-    // /// that there's a subscription to the current one.  If there isn't, then
-    // /// subscribe to it.
-    // fn subscribe_or_unsubscribe_as_needed(&mut self, tl: Timeline) -> Result<()> {
-    //     let timelines_to_modify = self.msg_queues.calculate_timelines_to_add_or_drop(tl);
-
-    //     // Record the lower number of clients subscribed to that channel
-    //     for change in timelines_to_modify {
-    //         let timeline = change.timeline;
-
-    //         let count_of_subscribed_clients = self
-    //             .clients_per_timeline
-    //             .entry(timeline)
-    //             .and_modify(|n| *n += change.in_subscriber_number)
-    //             .or_insert_with(|| 1);
-
-    //         // If no clients, unsubscribe from the channel
-    //         use RedisCmd::*;
-    //         if *count_of_subscribed_clients <= 0 {
-    //             self.redis_connection.send_cmd(Unsubscribe, &timeline)?;
-    //         } else if *count_of_subscribed_clients == 1 && change.in_subscriber_number == 1 {
-    //             self.redis_connection.send_cmd(Subscribe, &timeline)?
-    //         }
-    //     }
-    //     Ok(())
-    // }
 }

--- a/src/redis_to_client_stream/redis/redis_connection/mod.rs
+++ b/src/redis_to_client_stream/redis/redis_connection/mod.rs
@@ -61,7 +61,8 @@ impl RedisConn {
         if self.redis_polled_at.elapsed() > self.redis_poll_interval {
             if let Ok(bytes_read) = self.primary.read(&mut buffer) {
                 self.redis_input.extend_from_slice(&buffer[..bytes_read]);
-            }
+            };
+            self.redis_polled_at = Instant::now();
         }
         if self.redis_input.is_empty() {
             return Ok(Async::NotReady);


### PR DESCRIPTION
This PR contains several changes, all aimed at addressing the high CPU usage/iowait times noted in #123.

First, it removes code that automatically closed WebSocket connections after a period of inactivity and changes to checking for closed connections only when attempting to send a message or ping.  This may lead to a slight delay in Flodgatt knowing that a client has closed a connection, but this delay should not have any impact – Flodgatt will find out about the closed connection before it needs to do anything with it.

Second, this PR removes code that caused Flodgatt to check for incoming WebSocket messages.  We do not currently support taking any actions based on messages from the client, so there is no reason to pay the performance cost associated with checking for those messages.  (However, this may change when #121 is implemented; for that reason, I left a comment indicating how and where to add that code later).

Third, this PR fixes a bug that caused Redis to erroneously be polled more often than it should have been.

Between these three changes, I _believe_ that #123 is resolved.  However, there is one other factor that contributed to #123 – when building Flodgatt, I did not consider that it might need to share responsibility for streaming connections with the Node streaming server.  Thus, when Flodgatt noticed that it had not sent any WS messages to the half of the connections the Node server was handling, it treated those connections as though they had been dropped and attempted to close them – all at exactly the same time.  This is what lead to the high iowait spikes.

I _believe_ that the changes in this PR will also resolve this issue, since Flodgatt no longer attempts to automatically clean up idle connections.  However, before totally declaring victory, I would like to run some tests/benchmarks.  I will split that testing into a separate PR.  

