### PR TITLE
Benchmark & performance tune

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
+load_test.sh
+/benches/perf_statistics
 **/*.rs.bk

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: rust
 rust:
   - stable
+  - beta
+jobs:
+  fast_finish: true
 cache: cargo
+branches:
+  only:
+    - master

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flodgatt"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -419,7 +419,6 @@ dependencies = [
  "pretty_env_logger 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2_postgres 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flodgatt"
 description = "A blazingly fast drop-in replacement for the Mastodon streaming api server"
-version = "0.8.4"
+version = "0.8.5"
 authors = ["Daniel Long Sockwell <daniel@codesections.com", "Julian Laubstein <contact@julianlaubstein.de>"]
 edition = "2018"
 
@@ -28,12 +28,11 @@ hashbrown = "0.7.1"
 
 [dev-dependencies]
 criterion = "0.3"
-regex = "1.3.2"
+
 
 [[bench]]
 name = "parse_redis"
 harness = false
-
 
 [features]
 default = [ "production" ]
@@ -43,7 +42,7 @@ production = []
 
 [profile.release]
 lto = "fat"
-#panic = "abort"
+panic = "abort"
 codegen-units = 1
 
 

--- a/benches/parse_redis.rs
+++ b/benches/parse_redis.rs
@@ -1,8 +1,8 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use flodgatt::{
-    messages::*,
-    parse_client_request::{Content::*, Reach::*, Stream::*, Timeline},
-    redis_to_client_stream::{RedisMsg, RedisParseOutput},
+    event::*,
+    request::{Content::*, Reach::*, Stream::*, Timeline},
+    response::{RedisMsg, RedisParseOutput},
 };
 use lru::LruCache;
 use std::convert::TryFrom;
@@ -19,16 +19,15 @@ fn parse_long_redis_input<'a>(input: &'a str) -> RedisMsg<'a> {
 fn parse_to_timeline(msg: RedisMsg) -> Timeline {
     let trimmed_tl_txt = &msg.timeline_txt["timeline:".len()..];
     let tl = Timeline::from_redis_text(trimmed_tl_txt, &mut LruCache::new(1000)).unwrap();
-    assert_eq!(tl, Timeline(User(1), Federated, All));
+    assert_eq!(tl, Timeline(User(Id(1)), Federated, All));
     tl
 }
 fn parse_to_checked_event(msg: RedisMsg) -> Event {
     Event::TypeSafe(serde_json::from_str(msg.event_txt).unwrap())
 }
 
-fn parse_to_dyn_event(msg: RedisMsg) -> String {
-    let event: Event = Event::Dynamic(serde_json::from_str(msg.event_txt).unwrap());
-    event.to_json_string()
+fn parse_to_dyn_event(msg: RedisMsg) -> Event {
+    Event::Dynamic(serde_json::from_str(msg.event_txt).unwrap())
 }
 
 fn redis_msg_to_event_string(msg: RedisMsg) -> String {
@@ -43,16 +42,16 @@ fn criterion_benchmark(c: &mut Criterion) {
     let input = ONE_MESSAGE_FOR_THE_USER_TIMLINE_FROM_REDIS;
     let mut group = c.benchmark_group("Parse redis RESP array");
 
-    // group.bench_function("parse redis input to RedisMsg", |b| {
-    //     b.iter(|| black_box(parse_long_redis_input(input)))
-    // });
+    group.bench_function("parse redis input to RedisMsg", |b| {
+        b.iter(|| black_box(parse_long_redis_input(input)))
+    });
 
     let msg = parse_long_redis_input(input);
-    // group.bench_function("parse RedisMsg to Timeline", |b| {
-    //     b.iter(|| black_box(parse_to_timeline(msg.clone())))
-    // });
+    group.bench_function("parse RedisMsg to Timeline", |b| {
+        b.iter(|| black_box(parse_to_timeline(msg.clone())))
+    });
 
-    group.bench_function("parse RedisMsg -> DynamicEvent -> JSON string", |b| {
+    group.bench_function("parse RedisMsg -> DynamicEvent", |b| {
         b.iter(|| black_box(parse_to_dyn_event(msg.clone())))
     });
 

--- a/load_test.sample
+++ b/load_test.sample
@@ -1,0 +1,20 @@
+#!/bin/sh
+instance='127.0.0.1:4000'
+timeline='public:local'
+number_of_ws=300
+
+command -v websocat >/dev/null || { echo >&2 "Install websocat with `cargo install websocat` to use this script"; exit 1; }
+
+
+echo "Opening $number_of_ws WebSockets to $timeline"
+for i in $(seq 0 $number_of_ws); do
+    sleep 0.1
+    websocat wss://${instance}/api/v1/streaming/?stream=${timeline} --no-close > /dev/null &
+done
+
+echo "$number_of_ws WebSocket connections established..."
+
+sleep 60
+
+echo "Closing WebSockets"
+echo "Done"

--- a/src/response/redis/connection.rs
+++ b/src/response/redis/connection.rs
@@ -58,7 +58,7 @@ impl RedisConn {
                 Err(_) => break,
             };
             if first_read {
-                size = 2000;
+                size = 5000;
                 buffer = vec![0_u8; size];
                 first_read = false;
             }
@@ -115,6 +115,14 @@ impl RedisConn {
             Timeline(Stream::Hashtag(id), _, _) => self.tag_name_cache.get(id),
             _non_hashtag_timeline => None,
         };
+        log::info!(
+            "RedisConn.redis_input size: {}\n\
+             RedisConn.redis_input capacity: {}\n\
+             RedisConn.redis_input length: {}",
+            std::mem::size_of_val(&self.redis_input),
+            self.redis_input.capacity(),
+            self.redis_input.len()
+        );
 
         let tl = timeline.to_redis_raw_timeline(hashtag)?;
         let (primary_cmd, secondary_cmd) = cmd.into_sendable(&tl);

--- a/src/response/redis/msg.rs
+++ b/src/response/redis/msg.rs
@@ -36,8 +36,6 @@ pub enum RedisParseOutput<'a> {
     NonMsg(&'a str),
 }
 
-// TODO -- should this impl Iterator?
-
 #[derive(Debug, Clone, PartialEq)]
 pub struct RedisMsg<'a> {
     pub timeline_txt: &'a str,


### PR DESCRIPTION
This PR reflects work done to further tune Flodgatt's performance, including the addition of a load-testing script.

The `load_test.sample` script provides a **very** minimal way to test flodgatt under load: it opens multiple WebSocket connections using [websocat](https://github.com/vi/websocat).  The sample script tests with 300 connections, because that is the about most nginx will support without adjusting settings as described in the [blog post on scaling Mastodon](https://blog.joinmastodon.org/2017/04/scaling-mastodon/).  I've made those setting changes and have been testing with 900 connections – and it still runs fine on a $5/month Digital Ocean VPS.

In addition to monitoring resource use with `htop` and `ps_mem`, I also profiled the code with `perf` during these load tests.  All of this testing did not turn up much in the way of performance hot spots – which greatly increases my confidence in flodgatt's overall performance.

I did notice a very minor performance issue (flodgatt was unnecessarily allocating a new byte buffer each time it polled Redis instead of re-using the old one and overwriting data.  This PR also fixes that issue, leading to a ~3% reduction in memory use during the load test. 

Finally, this PR also tweaks the `travis.yaml` file to build against both Rust stable and Rust beta (in order to detect the extremely-unlikely event of a language change that breaks our code).  In order to avoid using additional CI resources, it also eliminates builds on branch creation, since they're duplicated when the PR is made against master anyway.