### PR TITLE
Update concurrency primitive.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,7 @@ dependencies = [
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "urlencoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "warp 0.1.20 (git+https://github.com/seanmonstar/warp.git)",
 ]
 
@@ -2224,6 +2225,14 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2589,6 +2598,7 @@ dependencies = [
 "checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
 "checksum urlencoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3df3561629a8bb4c57e5a2e4c43348d9e29c7c29d9b1c4c1f47166deca8f37ed"
 "checksum utf-8 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
+"checksum uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flodgatt"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flodgatt"
 description = "A blazingly fast drop-in replacement for the Mastodon streaming api server"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Daniel Long Sockwell <daniel@codesections.com", "Julian Laubstein <contact@julianlaubstein.de>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ r2d2 = "0.8.8"
 lru = "0.4.3"
 urlencoding = "1.0.0"
 hashbrown = "0.7.1"
+uuid = { version = "0.8.1", features = ["v4"] }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/response/event.rs
+++ b/src/response/event.rs
@@ -12,7 +12,7 @@ use std::convert::TryFrom;
 use std::string::String;
 use warp::sse::ServerSentEvent;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Event {
     TypeSafe(CheckedEvent),
     Dynamic(DynEvent),

--- a/src/response/event/checked_event.rs
+++ b/src/response/event/checked_event.rs
@@ -22,7 +22,7 @@ use serde::Deserialize;
 
 #[serde(rename_all = "snake_case", tag = "event", deny_unknown_fields)]
 #[rustfmt::skip]
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum CheckedEvent {
     Update { payload: Status, queued_at: Option<i64> },
     Notification { payload: Notification },

--- a/src/response/event/checked_event/account.rs
+++ b/src/response/event/checked_event/account.rs
@@ -3,7 +3,7 @@ use crate::Id;
 use serde::{Deserialize, Serialize};
 
 #[serde(deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub(super) struct Account {
     pub id: Id,
     username: String,
@@ -31,7 +31,7 @@ pub(super) struct Account {
 }
 
 #[serde(deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 struct Field {
     name: String,
     value: String,
@@ -39,7 +39,7 @@ struct Field {
 }
 
 #[serde(deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 struct Source {
     note: String,
     fields: Vec<Field>,

--- a/src/response/event/checked_event/announcement.rs
+++ b/src/response/event/checked_event/announcement.rs
@@ -2,7 +2,7 @@ use super::{emoji::Emoji, mention::Mention, tag::Tag, AnnouncementReaction};
 use serde::{Deserialize, Serialize};
 
 #[serde(deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Announcement {
     // Fully undocumented
     id: String,

--- a/src/response/event/checked_event/announcement_reaction.rs
+++ b/src/response/event/checked_event/announcement_reaction.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[serde(deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct AnnouncementReaction {
     #[serde(skip_serializing_if = "Option::is_none")]
     announcement_id: Option<String>,

--- a/src/response/event/checked_event/conversation.rs
+++ b/src/response/event/checked_event/conversation.rs
@@ -2,7 +2,7 @@ use super::{account::Account, status::Status};
 use serde::{Deserialize, Serialize};
 
 #[serde(deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Conversation {
     id: String,
     accounts: Vec<Account>,

--- a/src/response/event/checked_event/emoji.rs
+++ b/src/response/event/checked_event/emoji.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[serde(deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub(super) struct Emoji {
     shortcode: String,
     url: String,

--- a/src/response/event/checked_event/mention.rs
+++ b/src/response/event/checked_event/mention.rs
@@ -2,7 +2,7 @@ use crate::Id;
 use serde::{Deserialize, Serialize};
 
 #[serde(deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub(super) struct Mention {
     pub id: Id,
     username: String,

--- a/src/response/event/checked_event/notification.rs
+++ b/src/response/event/checked_event/notification.rs
@@ -2,7 +2,7 @@ use super::{account::Account, status::Status};
 use serde::{Deserialize, Serialize};
 
 #[serde(deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Notification {
     id: String,
     r#type: NotificationType,
@@ -12,7 +12,7 @@ pub struct Notification {
 }
 
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 enum NotificationType {
     Follow,
     FollowRequest, // Undocumented

--- a/src/response/event/checked_event/status.rs
+++ b/src/response/event/checked_event/status.rs
@@ -20,7 +20,7 @@ use std::boxed::Box;
 use std::string::String;
 
 #[serde(deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Status {
     id: Id,
     uri: String,

--- a/src/response/event/checked_event/status/application.rs
+++ b/src/response/event/checked_event/status/application.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[serde(deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub(super) struct Application {
     name: String,
     website: Option<String>,

--- a/src/response/event/checked_event/status/attachment.rs
+++ b/src/response/event/checked_event/status/attachment.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[serde(deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub(super) struct Attachment {
     id: String,
     r#type: AttachmentType,
@@ -15,7 +15,7 @@ pub(super) struct Attachment {
 }
 
 #[serde(rename_all = "lowercase", deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 enum AttachmentType {
     Unknown,
     Image,

--- a/src/response/event/checked_event/status/card.rs
+++ b/src/response/event/checked_event/status/card.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[serde(deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub(super) struct Card {
     url: String,
     title: String,
@@ -19,7 +19,7 @@ pub(super) struct Card {
 }
 
 #[serde(rename_all = "lowercase", deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 enum CardType {
     Link,
     Photo,

--- a/src/response/event/checked_event/status/poll.rs
+++ b/src/response/event/checked_event/status/poll.rs
@@ -2,7 +2,7 @@ use super::super::emoji::Emoji;
 use serde::{Deserialize, Serialize};
 
 #[serde(deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub(super) struct Poll {
     id: String,
     expires_at: String,
@@ -17,7 +17,7 @@ pub(super) struct Poll {
 }
 
 #[serde(deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 struct PollOptions {
     title: String,
     votes_count: Option<i32>,

--- a/src/response/event/checked_event/tag.rs
+++ b/src/response/event/checked_event/tag.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[serde(deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub(super) struct Tag {
     name: String,
     url: String,
@@ -9,7 +9,7 @@ pub(super) struct Tag {
 }
 
 #[serde(deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 struct History {
     day: String,
     uses: String,

--- a/src/response/event/checked_event/visibility.rs
+++ b/src/response/event/checked_event/visibility.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[serde(rename_all = "lowercase", deny_unknown_fields)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub(super) enum Visibility {
     Public,
     Unlisted,

--- a/src/response/event/dynamic_event.rs
+++ b/src/response/event/dynamic_event.rs
@@ -8,7 +8,7 @@ use hashbrown::HashSet;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct DynEvent {
     #[serde(skip)]
     pub(crate) kind: EventKind,
@@ -17,7 +17,7 @@ pub struct DynEvent {
     pub(crate) queued_at: Option<i64>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum EventKind {
     Update(DynStatus),
     NonUpdate,
@@ -29,7 +29,7 @@ impl Default for EventKind {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct DynStatus {
     pub(crate) id: Id,
     pub(crate) username: String,

--- a/src/response/redis/manager/err.rs
+++ b/src/response/redis/manager/err.rs
@@ -6,6 +6,7 @@ use std::fmt;
 #[derive(Debug)]
 pub enum Error {
     InvalidId,
+
     TimelineErr(TimelineErr),
     EventErr(EventErr),
     RedisParseErr(RedisParseErr),
@@ -22,7 +23,7 @@ impl fmt::Display for Error {
         match self {
             InvalidId => write!(
                 f,
-                "Attempted to get messages for a subscription that had not been set up."
+                "tried to access a timeline/channel subscription that does not exist"
             ),
             EventErr(inner) => write!(f, "{}", inner),
             RedisParseErr(inner) => write!(f, "{}", inner),

--- a/src/response/redis/manager/err.rs
+++ b/src/response/redis/manager/err.rs
@@ -11,6 +11,7 @@ pub enum Error {
     RedisParseErr(RedisParseErr),
     RedisConnErr(RedisConnErr),
     ChannelSendErr(tokio::sync::watch::error::SendError<(Timeline, Event)>),
+    ChannelSendErr2(tokio::sync::mpsc::error::UnboundedTrySendError<Event>),
 }
 
 impl std::error::Error for Error {}
@@ -28,6 +29,7 @@ impl fmt::Display for Error {
             RedisConnErr(inner) => write!(f, "{}", inner),
             TimelineErr(inner) => write!(f, "{}", inner),
             ChannelSendErr(inner) => write!(f, "{}", inner),
+            ChannelSendErr2(inner) => write!(f, "{}", inner),
         }?;
         Ok(())
     }
@@ -36,6 +38,11 @@ impl fmt::Display for Error {
 impl From<tokio::sync::watch::error::SendError<(Timeline, Event)>> for Error {
     fn from(error: tokio::sync::watch::error::SendError<(Timeline, Event)>) -> Self {
         Self::ChannelSendErr(error)
+    }
+}
+impl From<tokio::sync::mpsc::error::UnboundedTrySendError<Event>> for Error {
+    fn from(error: tokio::sync::mpsc::error::UnboundedTrySendError<Event>) -> Self {
+        Self::ChannelSendErr2(error)
     }
 }
 

--- a/src/response/stream/sse.rs
+++ b/src/response/stream/sse.rs
@@ -1,44 +1,29 @@
 use super::{Event, Payload};
-use crate::request::{Subscription, Timeline};
+use crate::request::Subscription;
 
 use futures::stream::Stream;
-use log;
 use std::time::Duration;
-use tokio::sync::{mpsc, watch};
+use tokio::sync::mpsc::UnboundedReceiver;
 use warp::reply::Reply;
 use warp::sse::Sse as WarpSse;
 
-pub struct Sse;
+type EventRx = UnboundedReceiver<Event>;
+
+pub struct Sse(Subscription);
 
 impl Sse {
-    pub fn send_events(
-        sse: WarpSse,
-        mut unsubscribe_tx: mpsc::UnboundedSender<Timeline>,
-        subscription: Subscription,
-        sse_rx: watch::Receiver<(Timeline, Event)>,
-    ) -> impl Reply {
-        let target_timeline = subscription.timeline;
+    pub fn new(subscription: Subscription) -> Self {
+        Self(subscription)
+    }
 
-        let event_stream = sse_rx
-            .filter(move |(timeline, _)| target_timeline == *timeline)
-            .filter_map(move |(_timeline, event)| {
-                match (event.update_payload(), event.dyn_update_payload()) {
-                    (Some(update), _) if Sse::update_not_filtered(subscription.clone(), update) => {
-                        event.to_warp_reply()
-                    }
-                    (None, None) => event.to_warp_reply(), // send all non-updates
-                    (_, Some(update)) if Sse::update_not_filtered(subscription.clone(), update) => {
-                        event.to_warp_reply()
-                    }
-                    (_, _) => None,
-                }
-            })
-            .then(move |res| {
-                unsubscribe_tx
-                    .try_send(target_timeline)
-                    .unwrap_or_else(|e| log::error!("could not unsubscribe from channel: {}", e));
-                res
-            });
+    pub fn send_events(self, sse: WarpSse, event_rx: EventRx) -> impl Reply {
+        let event_stream = event_rx.filter_map(move |event| {
+            match (event.update_payload(), event.dyn_update_payload()) {
+                (Some(update), _) if self.update_not_filtered(update) => event.to_warp_reply(),
+                (_, Some(update)) if self.update_not_filtered(update) => event.to_warp_reply(),
+                (_, _) => event.to_warp_reply(), // send all non-updates
+            }
+        });
 
         sse.reply(
             warp::sse::keep_alive()
@@ -48,11 +33,11 @@ impl Sse {
         )
     }
 
-    fn update_not_filtered(subscription: Subscription, update: &impl Payload) -> bool {
-        let blocks = &subscription.blocks;
-        let allowed_langs = &subscription.allowed_langs;
+    fn update_not_filtered(&self, update: &impl Payload) -> bool {
+        let blocks = &self.0.blocks;
+        let allowed_langs = &self.0.allowed_langs;
 
-        match subscription.timeline {
+        match self.0.timeline {
             tl if tl.is_public()
                 && !update.language_unset()
                 && !allowed_langs.is_empty()

--- a/src/response/stream/ws.rs
+++ b/src/response/stream/ws.rs
@@ -1,7 +1,8 @@
 use super::{Event, Payload};
 use crate::request::Subscription;
 
-use futures::{future::Future, stream::Stream};
+use futures::future::Future;
+use futures::stream::Stream;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use warp::ws::{Message, WebSocket};
 
@@ -31,9 +32,7 @@ impl Ws {
                 .map(|_r| ())
                 .map_err(|e| {
                     match e.to_string().as_ref() {
-                        "IO error: Broken pipe (os error 32)" => {
-                            log::info!("Client connection lost")
-                        } // just closed unix socket
+                        "IO error: Broken pipe (os error 32)" => (), // just closed unix socket
                         _ => log::warn!("WebSocket send error: {}", e),
                     }
                 }),


### PR DESCRIPTION
This PR solves the backpressure issue that (in rare cases) could previously lead to delays in sending messages by switching to a different concurrency primitive.

 This change resolves the backpressure issue; however, I am holding off on releasing a new version, because the current implementation created a performance regression, in that it increased Flodgatt's memory consumption.  In my load testing, Flodgatt's memory use after this PR was nearly 50% of the Node server's memory use, which is higher than I would prefer.  I have some ideas on reducing this overhead, which I will implement in a followup PR. 