### PR TITLE
`redis_namespace` fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flodgatt"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flodgatt"
 description = "A blazingly fast drop-in replacement for the Mastodon streaming api server"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Daniel Long Sockwell <daniel@codesections.com", "Julian Laubstein <contact@julianlaubstein.de>"]
 edition = "2018"
 

--- a/src/response/event.rs
+++ b/src/response/event.rs
@@ -103,7 +103,7 @@ impl Event {
                 Conversation         { payload, .. } => Some(escaped(payload)),
                 Announcement         { payload, .. } => Some(escaped(payload)),
                 AnnouncementReaction { payload, .. } => Some(escaped(payload)),
-                AnnouncementDelete   { payload, .. } => Some(payload.clone()),
+                AnnouncementDelete   { payload, .. } |
                 Delete               { payload, .. } => Some(payload.clone()),
                 FiltersChanged                       => None,
             },


### PR DESCRIPTION
This fixes a bug that would cause Redis commands not to be sent properly when users had set the `REDIS_NAMESPACE` environmental variable.