### PR TITLE
Improve handling of large Redis input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flodgatt"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flodgatt"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flodgatt"
 description = "A blazingly fast drop-in replacement for the Mastodon streaming api server"
-version = "0.9.5"
+version = "0.9.6"
 authors = ["Daniel Long Sockwell <daniel@codesections.com", "Julian Laubstein <contact@julianlaubstein.de>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flodgatt"
 description = "A blazingly fast drop-in replacement for the Mastodon streaming api server"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Daniel Long Sockwell <daniel@codesections.com", "Julian Laubstein <contact@julianlaubstein.de>"]
 edition = "2018"
 

--- a/benches/parse_redis.rs
+++ b/benches/parse_redis.rs
@@ -1,9 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use flodgatt::{
-    event::*,
-    request::{Content::*, Reach::*, Stream::*, Timeline},
-    response::{RedisMsg, RedisParseOutput},
-};
+use flodgatt::response::{RedisMsg, RedisParseOutput};
 use lru::LruCache;
 use std::convert::TryFrom;
 
@@ -16,27 +12,27 @@ fn parse_long_redis_input<'a>(input: &'a str) -> RedisMsg<'a> {
     }
 }
 
-fn parse_to_timeline(msg: RedisMsg) -> Timeline {
-    let trimmed_tl_txt = &msg.timeline_txt["timeline:".len()..];
-    let tl = Timeline::from_redis_text(trimmed_tl_txt, &mut LruCache::new(1000)).unwrap();
-    assert_eq!(tl, Timeline(User(Id(1)), Federated, All));
-    tl
-}
-fn parse_to_checked_event(msg: RedisMsg) -> EventKind {
-    EventKind::TypeSafe(serde_json::from_str(msg.event_txt).unwrap())
-}
+// fn parse_to_timeline(msg: RedisMsg) -> Timeline {
+//     let trimmed_tl_txt = &msg.timeline_txt["timeline:".len()..];
+//     let tl = Timeline::from_redis_text(trimmed_tl_txt, &mut LruCache::new(1000)).unwrap();
+//     assert_eq!(tl, Timeline(User(Id(1)), Federated, All));
+//     tl
+// }
+// fn parse_to_checked_event(msg: RedisMsg) -> EventKind {
+//     EventKind::TypeSafe(serde_json::from_str(msg.event_txt).unwrap())
+// }
 
-fn parse_to_dyn_event(msg: RedisMsg) -> EventKind {
-    EventKind::Dynamic(serde_json::from_str(msg.event_txt).unwrap())
-}
+// fn parse_to_dyn_event(msg: RedisMsg) -> EventKind {
+//     EventKind::Dynamic(serde_json::from_str(msg.event_txt).unwrap())
+// }
 
-fn redis_msg_to_event_string(msg: RedisMsg) -> String {
-    msg.event_txt.to_string()
-}
+// fn redis_msg_to_event_string(msg: RedisMsg) -> String {
+//     msg.event_txt.to_string()
+// }
 
-fn string_to_checked_event(event_txt: &String) -> EventKind {
-    EventKind::TypeSafe(serde_json::from_str(event_txt).unwrap())
-}
+// fn string_to_checked_event(event_txt: &String) -> EventKind {
+//     EventKind::TypeSafe(serde_json::from_str(event_txt).unwrap())
+// }
 
 fn criterion_benchmark(c: &mut Criterion) {
     let input = ONE_MESSAGE_FOR_THE_USER_TIMLINE_FROM_REDIS;
@@ -46,25 +42,25 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| black_box(parse_long_redis_input(input)))
     });
 
-    let msg = parse_long_redis_input(input);
-    group.bench_function("parse RedisMsg to Timeline", |b| {
-        b.iter(|| black_box(parse_to_timeline(msg.clone())))
-    });
+    // let msg = parse_long_redis_input(input);
+    // group.bench_function("parse RedisMsg to Timeline", |b| {
+    //     b.iter(|| black_box(parse_to_timeline(msg.clone())))
+    // });
 
-    group.bench_function("parse RedisMsg -> DynamicEvent", |b| {
-        b.iter(|| black_box(parse_to_dyn_event(msg.clone())))
-    });
+    // group.bench_function("parse RedisMsg -> DynamicEvent", |b| {
+    //     b.iter(|| black_box(parse_to_dyn_event(msg.clone())))
+    // });
 
-    group.bench_function("parse RedisMsg -> CheckedEvent", |b| {
-        b.iter(|| black_box(parse_to_checked_event(msg.clone())))
-    });
+    // group.bench_function("parse RedisMsg -> CheckedEvent", |b| {
+    //     b.iter(|| black_box(parse_to_checked_event(msg.clone())))
+    // });
 
-    group.bench_function("parse RedisMsg -> String -> CheckedEvent", |b| {
-        b.iter(|| {
-            let txt = black_box(redis_msg_to_event_string(msg.clone()));
-            black_box(string_to_checked_event(&txt));
-        })
-    });
+    // group.bench_function("parse RedisMsg -> String -> CheckedEvent", |b| {
+    //     b.iter(|| {
+    //         let txt = black_box(redis_msg_to_event_string(msg.clone()));
+    //         black_box(string_to_checked_event(&txt));
+    //     })
+    // });
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/src/err.rs
+++ b/src/err.rs
@@ -13,12 +13,6 @@ pub enum Error {
     Config(config::Error),
 }
 
-impl Error {
-    pub fn log(msg: impl fmt::Display) {
-        eprintln!("Error: {}", msg);
-    }
-}
-
 impl std::error::Error for Error {}
 
 impl fmt::Debug for Error {

--- a/src/err.rs
+++ b/src/err.rs
@@ -15,7 +15,7 @@ pub enum Error {
 
 impl Error {
     pub fn log(msg: impl fmt::Display) {
-        eprintln!("{}", msg);
+        eprintln!("Error: {}", msg);
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -118,6 +118,10 @@ impl Handler {
         warp::path!("api" / "v1" / "streaming" / "status" / "per_timeline").boxed()
     }
 
+    pub fn status_backpresure(&self) -> BoxedFilter<()> {
+        warp::path!("api" / "v1" / "streaming" / "status" / "backpresure").boxed()
+    }
+
     pub fn err(r: Rejection) -> std::result::Result<impl warp::Reply, warp::Rejection> {
         use StatusCode as Code;
         let (msg, code) = match &r.cause().map(|cause| cause.to_string()).as_deref() {

--- a/src/request/timeline.rs
+++ b/src/request/timeline.rs
@@ -35,7 +35,6 @@ impl Timeline {
     }
 
     pub(crate) fn to_redis_raw_timeline(&self, hashtag: Option<&String>) -> Result<String> {
-        // TODO -- does this need to account for namespaces?
         use {Content::*, Error::*, Reach::*, Stream::*};
 
         Ok(match self {

--- a/src/response.rs
+++ b/src/response.rs
@@ -14,4 +14,4 @@ mod stream;
 pub use redis::Error;
 
 #[cfg(feature = "bench")]
-pub use redis::msg::{RedisMsg, RedisParseOutput};
+pub use redis::{RedisMsg, RedisParseOutput};

--- a/src/response/redis.rs
+++ b/src/response/redis.rs
@@ -7,6 +7,9 @@ pub(self) use connection::RedisConn;
 pub use manager::Error;
 pub use manager::Manager;
 
+#[cfg(feature = "bench")]
+pub use msg::{RedisMsg, RedisParseOutput};
+
 use connection::RedisConnErr;
 use msg::RedisParseErr;
 
@@ -16,44 +19,50 @@ enum RedisCmd {
 }
 
 impl RedisCmd {
-    fn into_sendable(self, tl: &str) -> (Vec<u8>, Vec<u8>) {
+    fn into_sendable(self, timelines: &[String]) -> (Vec<u8>, Vec<u8>) {
         match self {
-            RedisCmd::Subscribe => (
-                [
-                    b"*2\r\n$9\r\nsubscribe\r\n$",
-                    tl.len().to_string().as_bytes(),
-                    b"\r\n",
-                    tl.as_bytes(),
-                    b"\r\n",
-                ]
-                .concat(),
-                [
-                    b"*3\r\n$3\r\nSET\r\n$",
-                    (tl.len() + "subscribed:".len()).to_string().as_bytes(),
-                    b"\r\nsubscribed:",
-                    tl.to_string().as_bytes(),
-                    b"\r\n$1\r\n1\r\n",
-                ]
-                .concat(),
-            ),
-            RedisCmd::Unsubscribe => (
-                [
-                    b"*2\r\n$11\r\nunsubscribe\r\n$",
-                    tl.len().to_string().as_bytes(),
-                    b"\r\n",
-                    tl.as_bytes(),
-                    b"\r\n",
-                ]
-                .concat(),
-                [
-                    b"*3\r\n$3\r\nSET\r\n$",
-                    (tl.len() + "subscribed:".len()).to_string().as_bytes(),
-                    b"\r\nsubscribed:",
-                    tl.to_string().as_bytes(),
-                    b"\r\n$1\r\n0\r\n",
-                ]
-                .concat(),
-            ),
+            RedisCmd::Subscribe => {
+                let primary = {
+                    let mut cmd = format!("*{}\r\n$9\r\nsubscribe\r\n", 1 + timelines.len());
+                    for tl in timelines {
+                        cmd.push_str(&format!("${}\r\n{}\r\n", tl.len(), tl));
+                    }
+                    cmd
+                };
+                let secondary = {
+                    let mut cmd = format!("*{}\r\n$4\r\nMSET\r\n", 1 + timelines.len());
+                    for tl in timelines {
+                        cmd.push_str(&format!(
+                            "${}\r\nsubscribed:{}\r\n$1\r\n$1\r\n",
+                            "subscribed:".len() + tl.len(),
+                            tl
+                        ));
+                    }
+                    cmd
+                };
+                (primary.as_bytes().to_vec(), secondary.as_bytes().to_vec())
+            }
+            RedisCmd::Unsubscribe => {
+                let primary = {
+                    let mut cmd = format!("*{}\r\n$11\r\nunsubscribe\r\n", 1 + timelines.len());
+                    for tl in timelines {
+                        cmd.push_str(&format!("${}\r\n{}\r\n", tl.len(), tl));
+                    }
+                    cmd
+                };
+                let secondary = {
+                    let mut cmd = format!("*{}\r\n$4\r\nMSET\r\n", 1 + timelines.len());
+                    for tl in timelines {
+                        cmd.push_str(&format!(
+                            "${}\r\nsubscribed:{}\r\n$1\r\n$0\r\n",
+                            "subscribed:".len() + tl.len(),
+                            tl
+                        ));
+                    }
+                    cmd
+                };
+                (primary.as_bytes().to_vec(), secondary.as_bytes().to_vec())
+            }
         }
     }
 }

--- a/src/response/redis/connection.rs
+++ b/src/response/redis/connection.rs
@@ -40,14 +40,15 @@ impl RedisConn {
             tag_id_cache: LruCache::new(1000),
             tag_name_cache: LruCache::new(1000),
             namespace: redis_cfg.namespace.clone().0,
-            input: vec![47_u8; 10_000], // TODO - set to something reasonable
+            input: vec![0; 4096 * 4],
         })
     }
     pub(super) fn poll_redis(&mut self, start: usize) -> Poll<usize, ManagerErr> {
-        const BLOCK: usize = 8192;
-        if self.input.len() <= start + BLOCK {
+        const BLOCK: usize = 4096 * 2;
+        if self.input.len() < start + BLOCK {
             self.input.resize(self.input.len() * 2, 0);
-            log::info!("Resizing input buffer. (Old input was {} bytes)", start);
+            log::info!("Resizing input buffer to {} KiB.", self.input.len() / 1024);
+            // log::info!("Current buffer: {}", String::from_utf8_lossy(&self.input));
         }
 
         use Async::*;

--- a/src/response/redis/connection/err.rs
+++ b/src/response/redis/connection/err.rs
@@ -31,7 +31,7 @@ impl fmt::Display for RedisConnErr {
                 addr, inner
             ),
             InvalidRedisReply(unexpected_reply) => format!(
-                "Received and unexpected reply from Redis.  Expected `+PONG` reply but got `{}`",
+                "Received and unexpected reply from Redis: `{}`",
                 unexpected_reply
             ),
             UnknownRedisErr(io_err) => {

--- a/src/response/redis/manager.rs
+++ b/src/response/redis/manager.rs
@@ -4,8 +4,8 @@
 mod err;
 pub use err::Error;
 
-use super::Event;
-use super::{RedisCmd, RedisConn};
+use super::msg::{RedisParseErr, RedisParseOutput};
+use super::{Event, RedisCmd, RedisConn};
 use crate::config;
 use crate::request::{Subscription, Timeline};
 
@@ -13,16 +13,19 @@ pub(self) use super::EventErr;
 
 use futures::Async;
 use hashbrown::{HashMap, HashSet};
+use std::convert::{TryFrom, TryInto};
+use std::str;
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::Sender;
 
 type Result<T> = std::result::Result<T, Error>;
+type EventChannel = Sender<Arc<Event>>;
 
 /// The item that streams from Redis and is polled by the `ClientAgent`
 pub struct Manager {
-    redis_connection: RedisConn,
-    timelines: HashMap<Timeline, HashMap<u32, Sender<Arc<Event>>>>,
+    redis_conn: RedisConn,
+    timelines: HashMap<Timeline, HashMap<u32, EventChannel>>,
     ping_time: Instant,
     channel_id: u32,
 }
@@ -31,7 +34,7 @@ impl Manager {
     /// Create a new `Manager`, with its own Redis connections (but no active subscriptions).
     pub fn try_from(redis_cfg: &config::Redis) -> Result<Self> {
         Ok(Self {
-            redis_connection: RedisConn::new(redis_cfg)?,
+            redis_conn: RedisConn::new(redis_cfg)?,
             timelines: HashMap::new(),
             ping_time: Instant::now(),
             channel_id: 0,
@@ -42,10 +45,10 @@ impl Manager {
         Arc::new(Mutex::new(self))
     }
 
-    pub fn subscribe(&mut self, subscription: &Subscription, channel: Sender<Arc<Event>>) {
+    pub fn subscribe(&mut self, subscription: &Subscription, channel: EventChannel) {
         let (tag, tl) = (subscription.hashtag_name.clone(), subscription.timeline);
         if let (Some(hashtag), Some(id)) = (tag, tl.tag()) {
-            self.redis_connection.update_cache(hashtag, id);
+            self.redis_conn.update_cache(hashtag, id);
         };
 
         let channels = self.timelines.entry(tl).or_default();
@@ -53,67 +56,99 @@ impl Manager {
         self.channel_id += 1;
 
         if channels.len() == 1 {
-            self.redis_connection
-                .send_cmd(RedisCmd::Subscribe, &tl)
+            self.redis_conn
+                .send_cmd(RedisCmd::Subscribe, &[tl])
                 .unwrap_or_else(|e| log::error!("Could not subscribe to the Redis channel: {}", e));
+            log::info!("Subscribed to {:?}", tl);
         };
     }
 
-    pub(crate) fn unsubscribe(&mut self, tl: &Timeline) -> Result<()> {
-        self.redis_connection.send_cmd(RedisCmd::Unsubscribe, &tl)?;
-        self.timelines.remove(&tl);
-        Ok(log::info!("Ended stream for {:?}", tl))
+    fn send_pings(&mut self) -> Result<()> {
+        // NOTE: this takes two cycles to close a connection after the client times out: on
+        // the first cycle, this successfully sends the Event to the response::Ws thread but
+        // that thread fatally errors sending to the client.  On the *second* cycle, this
+        // gets the error.  This isn't ideal, but is harmless.
+
+        self.ping_time = Instant::now();
+        let mut subscriptions_to_close = HashSet::new();
+        self.timelines.retain(|tl, channels| {
+            channels.retain(|_, chan| try_send_event(Arc::new(Event::Ping), chan, *tl).is_ok());
+
+            if channels.is_empty() {
+                subscriptions_to_close.insert(*tl);
+                false
+            } else {
+                true
+            }
+        });
+        if !subscriptions_to_close.is_empty() {
+            let timelines: Vec<_> = subscriptions_to_close.into_iter().collect();
+            &self
+                .redis_conn
+                .send_cmd(RedisCmd::Unsubscribe, &timelines[..])?;
+            log::info!("Unsubscribed from {:?}", timelines);
+        }
+
+        Ok(())
     }
 
     pub fn poll_broadcast(&mut self) -> Result<()> {
-        let mut completed_timelines = HashSet::new();
-        let log_send_err = |tl, e| Some(log::error!("cannot send to {:?}: {}", tl, e)).is_some();
-
         if self.ping_time.elapsed() > Duration::from_secs(30) {
-            self.ping_time = Instant::now();
-            for (tl, channels) in self.timelines.iter_mut() {
-                channels.retain(|_, chan| match chan.try_send(Arc::new(Event::Ping)) {
-                    Ok(()) => true,
-                    Err(e) if !e.is_closed() => log_send_err(*tl, e),
-                    Err(_) => false,
-                });
+            self.send_pings()?
+        }
 
-                // NOTE: this takes two cycles to close a connection after the client
-                // times out: on the first cycle, this fn sends the Event to the
-                // response::Ws thread without any error, but that thread encounters an
-                // error sending to the client and ends.  On the *second* cycle, this fn
-                // gets the error it's waiting on to clean up the connection.  This isn't
-                // ideal, but is harmless, since the only reason we haven't cleaned up the
-                // connection is that no messages are being sent to that client.
-                if channels.is_empty() {
-                    completed_timelines.insert(*tl);
-                }
-            }
-        };
+        let (mut unread_start, mut msg_end) = (0, 0);
 
-        loop {
-            match self.redis_connection.poll_redis() {
-                Ok(Async::NotReady) => break,
-                Ok(Async::Ready(Some((tl, event)))) => {
-                    let sendable_event = Arc::new(event);
-                    let channels = self.timelines.get_mut(&tl).ok_or(Error::InvalidId)?;
-                    channels.retain(|_, chan| match chan.try_send(sendable_event.clone()) {
-                        Ok(()) => true,
-                        Err(e) if !e.is_closed() => log_send_err(tl, e),
-                        Err(_) => false,
-                    });
-                    if channels.is_empty() {
-                        completed_timelines.insert(tl);
+        while let Async::Ready(msg_len) = self.redis_conn.poll_redis(msg_end)? {
+            msg_end += msg_len;
+            let input = &self.redis_conn.input[..msg_end];
+            let mut unread = str::from_utf8(input).unwrap_or_else(|e| {
+                str::from_utf8(input.split_at(e.valid_up_to()).0).expect("guaranteed by `split_at`")
+            });
+
+            while !unread.is_empty() {
+                let tag_id_cache = &mut self.redis_conn.tag_id_cache;
+                let redis_namespace = &self.redis_conn.namespace;
+
+                use {Error::InvalidId, RedisParseOutput::*};
+                unread = match RedisParseOutput::try_from(unread) {
+                    Ok(Msg(msg)) => {
+                        let trimmed_tl = match redis_namespace {
+                            Some(ns) if msg.timeline_txt.starts_with(ns) => {
+                                Some(&msg.timeline_txt[ns.len() + ":timeline:".len()..])
+                            }
+                            None => Some(&msg.timeline_txt["timeline:".len()..]),
+                            Some(_non_matching_ns) => None,
+                        };
+
+                        if let Some(trimmed_tl) = trimmed_tl {
+                            let tl = Timeline::from_redis_text(trimmed_tl, tag_id_cache)?;
+                            let event: Arc<Event> = Arc::new(msg.event_txt.try_into()?);
+                            let channels = self.timelines.get_mut(&tl).ok_or(InvalidId)?;
+                            channels.retain(|_, c| try_send_event(event.clone(), c, tl).is_ok());
+                        } else {
+                            // skip messages for different Redis namespaces
+                        }
+                        msg.leftover_input
                     }
+                    Ok(NonMsg(leftover_input)) => leftover_input,
+                    Err(RedisParseErr::Incomplete) => break,
+                    Err(e) => Err(e)?,
+                };
+                unread_start = msg_end - unread.len();
+            }
+            if !unread.is_empty() && unread_start > unread.len() {
+                log::info!("Re-using memory");
+                let (read, unread) = self.redis_conn.input[..msg_end].split_at_mut(unread_start);
+
+                for (i, b) in unread.iter().enumerate() {
+                    read[i] = *b;
                 }
-                Ok(Async::Ready(None)) => (), // cmd or msg for other namespace
-                Err(err) => log::error!("{}", err), // drop msg, log err, and proceed
+                msg_end = unread.len();
+                unread_start = 0;
             }
         }
 
-        for tl in &mut completed_timelines.iter() {
-            self.unsubscribe(tl)?;
-        }
         Ok(())
     }
 
@@ -144,5 +179,16 @@ impl Manager {
                 "\n*may include recently disconnected clients".to_string(),
             ))
             .collect()
+    }
+}
+
+fn try_send_event(event: Arc<Event>, chan: &mut EventChannel, tl: Timeline) -> Result<()> {
+    match chan.try_send(event) {
+        Ok(()) => Ok(()),
+        Err(e) if !e.is_closed() => {
+            log::error!("cannot send to {:?}: {}", tl, e);
+            Ok(())
+        }
+        Err(e) => Err(e)?,
     }
 }

--- a/src/response/redis/manager/err.rs
+++ b/src/response/redis/manager/err.rs
@@ -1,18 +1,18 @@
 use super::super::{RedisConnErr, RedisParseErr};
 use super::{Event, EventErr};
-use crate::request::{Timeline, TimelineErr};
+use crate::request::TimelineErr;
 
 use std::fmt;
+use std::sync::Arc;
+
 #[derive(Debug)]
 pub enum Error {
     InvalidId,
-
     TimelineErr(TimelineErr),
     EventErr(EventErr),
     RedisParseErr(RedisParseErr),
     RedisConnErr(RedisConnErr),
-    ChannelSendErr(tokio::sync::watch::error::SendError<(Timeline, Event)>),
-    ChannelSendErr2(tokio::sync::mpsc::error::UnboundedTrySendError<Event>),
+    ChannelSendErr(tokio::sync::mpsc::error::TrySendError<Arc<Event>>),
 }
 
 impl std::error::Error for Error {}
@@ -30,20 +30,14 @@ impl fmt::Display for Error {
             RedisConnErr(inner) => write!(f, "{}", inner),
             TimelineErr(inner) => write!(f, "{}", inner),
             ChannelSendErr(inner) => write!(f, "{}", inner),
-            ChannelSendErr2(inner) => write!(f, "{}", inner),
         }?;
         Ok(())
     }
 }
 
-impl From<tokio::sync::watch::error::SendError<(Timeline, Event)>> for Error {
-    fn from(error: tokio::sync::watch::error::SendError<(Timeline, Event)>) -> Self {
+impl From<tokio::sync::mpsc::error::TrySendError<Arc<Event>>> for Error {
+    fn from(error: tokio::sync::mpsc::error::TrySendError<Arc<Event>>) -> Self {
         Self::ChannelSendErr(error)
-    }
-}
-impl From<tokio::sync::mpsc::error::UnboundedTrySendError<Event>> for Error {
-    fn from(error: tokio::sync::mpsc::error::UnboundedTrySendError<Event>) -> Self {
-        Self::ChannelSendErr2(error)
     }
 }
 

--- a/src/response/redis/msg.rs
+++ b/src/response/redis/msg.rs
@@ -82,8 +82,11 @@ fn utf8_to_redis_data<'a>(s: &'a str) -> Result<(RedisData, &'a str), RedisParse
 
 fn after_newline_at(s: &str, start: usize) -> RedisParser<&str> {
     let s = s.get(start..).ok_or(Incomplete)?;
+    if s.len() < 2 {
+        Err(Incomplete)?;
+    }
     if !s.starts_with("\r\n") {
-        return Err(RedisParseErr::InvalidLineEnd);
+        Err(InvalidLineEnd)?;
     }
     Ok(s.get("\r\n".len()..).ok_or(Incomplete)?)
 }

--- a/src/response/stream/ws.rs
+++ b/src/response/stream/ws.rs
@@ -50,9 +50,12 @@ impl Ws {
                 e => log::warn!("WebSocket send error: {}", e),
             })
     }
-    fn filtered(&mut self, update: &impl Payload) -> bool {
+    fn filtered<T: std::fmt::Debug + Payload>(&mut self, update: &T) -> bool {
         let (blocks, allowed_langs) = (&self.0.blocks, &self.0.allowed_langs);
-        let skip = |msg| Some(log::info!("{:?} msg skipped - {}", self.0.timeline, msg)).is_some();
+        let skip = |msg| {
+            // Some(log::info!("{:?} msg skipped - {}\n{:?}", self.0.timeline, msg, update)).is_some()
+            Some(log::info!("{:?} msg skipped - {}", self.0.timeline, msg)).is_some()
+        };
 
         match self.0.timeline {
             tl if tl.is_public()


### PR DESCRIPTION
This PR improves how Flodgatt behaves when Redis has a very large number of messages available at the same time (a situation that is rare on small instances, but that could occur more frequently on larger instances). 
 
First, it implements a modified ring buffer and limits the amount of data it fetches from Redis in one syscall to 8 KiB (two pages on most systems). Flodgatt will process all complete messages it receives from Redis and then re-use the same buffer for the next time it retrieves data.  If
Flodgatt received a partial message, it will copy the partial message to the beginning of the buffer before its next read.

This change has little effect on Flodgatt under light load (because it was rare for Redis to have more than 8 KiB of messages available at any one time).  However, my hope is that this will significantly
reduce memory use on the largest instances.

Second, this PR alters how Flodgatt behaves if it receives enough messages for a single client to fill that client's channel. (Because the clients regularly send their messages, should only occur if a single client receives a large number of messages nearly simultaneously; this is rare, but could occur, especially on large instances).

Previously, Flodgatt would drop messages in the rare case when the client's channel was full.  Now, Flodgatt will pause the current Redis poll and yield control back to the client streams, allowing the
clients to empty their channels; Flodgatt will then resume polling Redis/sending the messages it previously received.  With the approach, Flodgatt will never drop messages.

This PR also adds a new `/status/backpressure` endpoint that displays the current length of the Redis input buffer (which should typically be low or 0).  Like the other `/status` endpoints, this
endpoint is only enabled when Flodgatt is compiled with the `stub_status` feature.
